### PR TITLE
Add triton MLA kernels for DeepSeek V4 sparse attention on SM120

### DIFF
--- a/run_sm120_flash.sh
+++ b/run_sm120_flash.sh
@@ -13,14 +13,57 @@ export VLLM_SM120_REFERENCE_QUERY_CHUNK_SIZE=128
 # export VLLM_SM120_REFERENCE_DEEPSEEK_V4_ATTENTION=1
 export VLLM_SM120_TRITON_MLA=1
     # /home/yiliu7/workspace/yi-dashboard/scripts/trace_gen.py \
+# source 
+# CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 \
+#     vllm serve \
+#     --model /media/yiliu7/deepseek-ai/DeepSeek-V4-Flash \
+#     --kv-cache-dtype fp8 \
+#     -tp 4 \
+#    --max-model-len 8192 \
+#    --max-num-batched-tokens 32768 \
+#      --gpu-memory-utilization 0.8 \
+#     --block-size 256 \
+#     --enable-expert-parallel  2>&1 | tee vllm_serve.log
+        # --max-num-batched-tokens 32768 \
+    #   --max-num-seqs 128
+    #     --max-num-batched-tokens 32768 \
+    # --tokenizer-mode deepseek_v4 
 
+    #  --max-num-batched-tokens 32768 
+    # --compilation-config '{"cudagraph_mode":"FULL_AND_PIECEWISE", "custom_ops":["all"]}' \
+
+# /home/yiliu7/workspace/yi-dashboard/scripts/trace_gen.py
+    # examples/basic/offline_inference/generate.py \
+
+VLLM_SM120_DISABLE_DEEPGEMM=1 \
 CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 .venv/bin/python \
     examples/basic/offline_inference/generate.py \
     --model /media/yiliu7/deepseek-ai/DeepSeek-V4-Flash \
-    -tp 4 --enforce-eager --kv-cache-dtype fp8 \
-    --max-model-len 2084 --gpu-memory-utilization 0.8
+    -tp 4  --kv-cache-dtype fp8 \
+    --max-model-len 2084 --gpu-memory-utilization 0.8 \
+    --enforce-eager
+
 # CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 .venv/bin/python \
-#     examples/basic/offline_inference/generate.py \
+#     /home/yiliu7/workspace/yi-dashboard/scripts/trace_gen.py \
 #     --model /media/yiliu7/deepseek-ai/DeepSeek-V4-Flash \
-#     -tp 4 --enforce-eager --kv-cache-dtype fp8 \
-#     --max-model-len 2084 --gpu-memory-utilization 0.8
+#     -tp 4  --kv-cache-dtype fp8 \
+#     --max-model-len 2084 --gpu-memory-utilization 0.8 \
+#     --enforce-eager
+
+# VLLM_SM120_DISABLE_DEEPGEMM=1 \
+# VLLM_ENABLE_V1_MULTIPROCESSING=0 VLLM_NUM_HIDDEN_LAYERS=4 \
+# CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 .venv/bin/python \
+#       examples/basic/offline_inference/generate.py  \
+#     --model /media/yiliu7/deepseek-ai/DeepSeek-V4-Flash \
+#     -tp 1  --kv-cache-dtype fp8 \
+#     --max-model-len 2084 --gpu-memory-utilization 0.8 \
+#     --enforce-eager
+
+# VLLM_SM120_DISABLE_DEEPGEMM=1 \
+# VLLM_ENABLE_V1_MULTIPROCESSING=0 VLLM_NUM_HIDDEN_LAYERS=4 \
+# CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 .venv/bin/python \
+#      /home/yiliu7/workspace/yi-dashboard/scripts/trace_gen.py  \
+#     --model /media/yiliu7/deepseek-ai/DeepSeek-V4-Flash \
+#     -tp 1  --kv-cache-dtype fp8 \
+#     --max-model-len 2084 --gpu-memory-utilization 0.8 \
+#     --enforce-eager

--- a/run_sm120_flash.sh
+++ b/run_sm120_flash.sh
@@ -9,6 +9,9 @@ export VLLM_SM120_REFERENCE_DEEPSEEK_V4_ATTENTION=1
 export VLLM_SM120_REFERENCE_TOPK_CHUNK_SIZE=256
 export VLLM_SM120_REFERENCE_QUERY_CHUNK_SIZE=128
 
+
+# export VLLM_SM120_REFERENCE_DEEPSEEK_V4_ATTENTION=1
+export VLLM_SM120_TRITON_MLA=1
     # /home/yiliu7/workspace/yi-dashboard/scripts/trace_gen.py \
 
 CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 .venv/bin/python \
@@ -16,3 +19,8 @@ CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 .venv/bin/python \
     --model /media/yiliu7/deepseek-ai/DeepSeek-V4-Flash \
     -tp 4 --enforce-eager --kv-cache-dtype fp8 \
     --max-model-len 2084 --gpu-memory-utilization 0.8
+# CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 .venv/bin/python \
+#     examples/basic/offline_inference/generate.py \
+#     --model /media/yiliu7/deepseek-ai/DeepSeek-V4-Flash \
+#     -tp 4 --enforce-eager --kv-cache-dtype fp8 \
+#     --max-model-len 2084 --gpu-memory-utilization 0.8

--- a/sm120-kernel-support-needed.md
+++ b/sm120-kernel-support-needed.md
@@ -56,7 +56,7 @@ All four kernel entry points (`sparse_prefill_fwd`, `sparse_decode_fwd`, `dense_
 - **Impact**: Sparse attention indexer — selects which KV tokens to attend to during decode
 - **Needs**: Compile for SM120
 
-### 5. FP8/FP4 MQA Logits (`fp8_fp4_mqa_logits`) -> skipped
+### 5. FP8/FP4 MQA Logits (`fp8_fp4_mqa_logits`) -> torch reference
 - **Current**: Same pattern
 - **Impact**: Non-paged MQA logits for prefill indexer
 - **Needs**: Same

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -174,6 +174,7 @@ if TYPE_CHECKING:
     VLLM_SM120_REFERENCE_DEEPSEEK_V4_ATTENTION: bool = False
     VLLM_SM120_REFERENCE_TOPK_CHUNK_SIZE: int | None = None
     VLLM_SM120_REFERENCE_QUERY_CHUNK_SIZE: int | None = None
+    VLLM_SM120_TRITON_MLA: bool = False
     VLLM_DEEP_GEMM_WARMUP: Literal[
         "skip",
         "full",
@@ -1292,6 +1293,9 @@ environment_variables: dict[str, Callable[[], Any]] = {
     ),
     "VLLM_SM120_REFERENCE_QUERY_CHUNK_SIZE": lambda: maybe_convert_int(
         os.getenv("VLLM_SM120_REFERENCE_QUERY_CHUNK_SIZE")
+    ),
+    "VLLM_SM120_TRITON_MLA": lambda: bool(
+        int(os.getenv("VLLM_SM120_TRITON_MLA", "0"))
     ),
     # DeepGemm JITs the kernels on-demand. The warmup attempts to make DeepGemm
     # JIT all the required kernels before model execution so there is no

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -175,6 +175,7 @@ if TYPE_CHECKING:
     VLLM_SM120_REFERENCE_TOPK_CHUNK_SIZE: int | None = None
     VLLM_SM120_REFERENCE_QUERY_CHUNK_SIZE: int | None = None
     VLLM_SM120_TRITON_MLA: bool = False
+    VLLM_SM120_DISABLE_DEEPGEMM: bool = False
     VLLM_DEEP_GEMM_WARMUP: Literal[
         "skip",
         "full",
@@ -1296,6 +1297,9 @@ environment_variables: dict[str, Callable[[], Any]] = {
     ),
     "VLLM_SM120_TRITON_MLA": lambda: bool(
         int(os.getenv("VLLM_SM120_TRITON_MLA", "0"))
+    ),
+    "VLLM_SM120_DISABLE_DEEPGEMM": lambda: bool(
+        int(os.getenv("VLLM_SM120_DISABLE_DEEPGEMM", "0"))
     ),
     # DeepGemm JITs the kernels on-demand. The warmup attempts to make DeepGemm
     # JIT all the required kernels before model execution so there is no

--- a/vllm/model_executor/layers/deepseek_v4_attention.py
+++ b/vllm/model_executor/layers/deepseek_v4_attention.py
@@ -88,6 +88,7 @@ _LEGACY_SM120_REFERENCE_ATTENTION_ENV = (
 )
 _LEGACY_SM120_REFERENCE_TOPK_CHUNK_ENV = "VLLM_SM120_REFERENCE_TOPK_CHUNK_SIZE"
 _LEGACY_SM120_REFERENCE_QUERY_CHUNK_ENV = "VLLM_SM120_REFERENCE_QUERY_CHUNK_SIZE"
+_TRITON_MLA_ENV = "VLLM_SM120_TRITON_MLA"
 _ENV_TRUE_VALUES = {"1", "true", "yes", "on"}
 _ENV_FALSE_VALUES = {"0", "false", "no", "off"}
 
@@ -126,6 +127,15 @@ def _is_sparse_mla_reference_attention_enabled(device: torch.device) -> bool:
     if legacy_configured is not None:
         return legacy_configured
     return _is_sm12x_device(device)
+
+
+def _is_triton_mla_enabled() -> bool:
+    """Check if triton MLA kernels should be used instead of torch reference.
+
+    Gated by VLLM_SM120_TRITON_MLA=1. When enabled, triton sparse MLA kernels
+    replace the pure-PyTorch reference attention paths for better performance.
+    """
+    return _optional_env_flag(_TRITON_MLA_ENV) or False
 
 
 def _sparse_mla_attention_dump_path() -> str:
@@ -1021,6 +1031,243 @@ class DeepseekV4MLAAttention(nn.Module, AttentionLayerBase):
         reference_output = merged_acc / merged_denom[:, :, None]
         output.copy_(reference_output.to(dtype=output.dtype))
 
+    def _forward_sparse_mla_swa_decode_triton(
+        self,
+        q: torch.Tensor,
+        swa_k_cache: torch.Tensor,
+        swa_metadata: "DeepseekSparseSWAMetadata",
+        output: torch.Tensor,
+    ) -> None:
+        """Triton kernel path for SWA-only decode attention."""
+        from vllm.v1.attention.ops.triton_mla_utils import (
+            merge_attention_with_sink,
+        )
+        from vllm.v1.attention.ops.triton_sparse_mla_kernel import (
+            triton_sparse_mla_attention,
+        )
+
+        num_decodes = swa_metadata.num_decodes
+        num_decode_tokens = swa_metadata.num_decode_tokens
+        assert num_decodes == num_decode_tokens
+
+        # Squeeze next_n dim if 4D: [T, 1, H, D] -> [T, H, D]
+        if q.dim() == 4:
+            q = q[:, 0, :, :]
+
+        swa_lens = swa_metadata.decode_swa_lens[:num_decode_tokens]
+        max_swa_len = swa_metadata.decode_swa_indices.shape[-1]
+        (gathered_kv,) = current_workspace_manager().get_simultaneous(
+            ((num_decode_tokens, max_swa_len, q.shape[-1]), torch.bfloat16),
+        )
+        gathered_kv.zero_()
+        dequantize_and_gather_k_cache(
+            gathered_kv,
+            swa_k_cache,
+            seq_lens=swa_metadata.seq_lens[:num_decodes],
+            gather_lens=swa_lens,
+            block_table=swa_metadata.block_table[:num_decodes],
+            block_size=swa_metadata.block_size,
+            offset=0,
+        )
+
+        # Reshape for triton kernel: kv=[T*max_swa_len, 1, D], indices=[T, 1, max_swa_len]
+        T = num_decode_tokens
+        D = q.shape[-1]
+        kv_flat = gathered_kv.reshape(T * max_swa_len, 1, D)
+
+        # Build identity indices: token i's KV is at [i*max_swa_len, (i+1)*max_swa_len)
+        indices = torch.arange(
+            max_swa_len, device=q.device, dtype=torch.int32
+        ).unsqueeze(0).expand(T, -1)
+        offsets = (torch.arange(T, device=q.device, dtype=torch.int32) * max_swa_len
+                  ).unsqueeze(1)
+        indices = (indices + offsets).unsqueeze(1)  # [T, 1, max_swa_len]
+
+        # Pad topk to multiple of 16 if needed
+        topk = indices.shape[-1]
+        pad = (16 - topk % 16) % 16
+        if pad > 0:
+            pad_indices = torch.full(
+                (T, 1, pad), -1, dtype=torch.int32, device=q.device
+            )
+            indices = torch.cat([indices, pad_indices], dim=-1)
+
+        triton_out, triton_lse = triton_sparse_mla_attention(
+            q=q,
+            kv=kv_flat,
+            indices=indices,
+            sm_scale=self.scale,
+            topk_length=swa_lens,
+            return_lse=True,
+        )
+
+        result = merge_attention_with_sink(triton_out, triton_lse, self.attn_sink)
+        output.copy_(result)
+
+    def _forward_sparse_mla_compressed_decode_triton(
+        self,
+        q: torch.Tensor,
+        compressed_k_cache: torch.Tensor,
+        swa_k_cache: torch.Tensor,
+        topk_indices: torch.Tensor,
+        topk_lens: torch.Tensor,
+        swa_metadata: "DeepseekSparseSWAMetadata",
+        attn_metadata: "FlashMLASparseMetadata",
+        output: torch.Tensor,
+    ) -> None:
+        """Triton kernel path for compressed + SWA decode attention."""
+        from vllm.v1.attention.ops.triton_mla_utils import (
+            lse_merge,
+            merge_attention_with_sink,
+        )
+        from vllm.v1.attention.ops.triton_sparse_mla_kernel import (
+            triton_sparse_mla_attention,
+        )
+
+        num_decodes = swa_metadata.num_decodes
+        num_decode_tokens = swa_metadata.num_decode_tokens
+        assert num_decodes == num_decode_tokens
+
+        # Squeeze next_n dim if 4D: [T, 1, H, D] -> [T, H, D]
+        if q.dim() == 4:
+            q = q[:, 0, :, :]
+
+        max_swa_len = swa_metadata.decode_swa_indices.shape[-1]
+        compressed_block_size = attn_metadata.block_size // self.compress_ratio
+        compressed_topk = topk_indices.shape[-1]
+        T = num_decode_tokens
+        D = q.shape[-1]
+
+        # --- Compressed attention ---
+        # Dequantize all compressed KV at once
+        (compressed_kv,) = current_workspace_manager().get_simultaneous(
+            ((T, compressed_topk, D), torch.bfloat16),
+        )
+        compressed_kv.zero_()
+        dequantize_global_slots_k_cache(
+            compressed_kv,
+            compressed_k_cache,
+            topk_indices,
+            block_size=compressed_block_size,
+        )
+
+        # Build flat KV + indices for compressed
+        comp_kv_flat = compressed_kv.reshape(T * compressed_topk, 1, D)
+        comp_indices = torch.arange(
+            compressed_topk, device=q.device, dtype=torch.int32
+        ).unsqueeze(0).expand(T, -1)
+        comp_offsets = (torch.arange(T, device=q.device, dtype=torch.int32)
+                       * compressed_topk).unsqueeze(1)
+        comp_indices = (comp_indices + comp_offsets).unsqueeze(1)
+
+        # Pad to multiple of 16
+        topk = comp_indices.shape[-1]
+        pad = (16 - topk % 16) % 16
+        if pad > 0:
+            pad_idx = torch.full(
+                (T, 1, pad), -1, dtype=torch.int32, device=q.device
+            )
+            comp_indices = torch.cat([comp_indices, pad_idx], dim=-1)
+
+        comp_out, comp_lse = triton_sparse_mla_attention(
+            q=q,
+            kv=comp_kv_flat,
+            indices=comp_indices,
+            sm_scale=self.scale,
+            topk_length=topk_lens,
+            return_lse=True,
+        )
+
+        # --- SWA attention ---
+        (swa_kv,) = current_workspace_manager().get_simultaneous(
+            ((T, max_swa_len, D), torch.bfloat16),
+        )
+        swa_kv.zero_()
+        swa_lens = swa_metadata.decode_swa_lens[:num_decode_tokens]
+        dequantize_and_gather_k_cache(
+            swa_kv,
+            swa_k_cache,
+            seq_lens=swa_metadata.seq_lens[:num_decodes],
+            gather_lens=swa_lens,
+            block_table=swa_metadata.block_table[:num_decodes],
+            block_size=swa_metadata.block_size,
+            offset=0,
+        )
+
+        swa_kv_flat = swa_kv.reshape(T * max_swa_len, 1, D)
+        swa_indices = torch.arange(
+            max_swa_len, device=q.device, dtype=torch.int32
+        ).unsqueeze(0).expand(T, -1)
+        swa_offsets = (torch.arange(T, device=q.device, dtype=torch.int32)
+                      * max_swa_len).unsqueeze(1)
+        swa_indices = (swa_indices + swa_offsets).unsqueeze(1)
+
+        swa_topk = swa_indices.shape[-1]
+        swa_pad = (16 - swa_topk % 16) % 16
+        if swa_pad > 0:
+            pad_idx = torch.full(
+                (T, 1, swa_pad), -1, dtype=torch.int32, device=q.device
+            )
+            swa_indices = torch.cat([swa_indices, pad_idx], dim=-1)
+
+        swa_out, swa_lse = triton_sparse_mla_attention(
+            q=q,
+            kv=swa_kv_flat,
+            indices=swa_indices,
+            sm_scale=self.scale,
+            topk_length=swa_lens,
+            return_lse=True,
+        )
+
+        # LSE merge compressed + SWA, then merge with sink
+        merged_out, merged_lse = lse_merge(comp_out, comp_lse, swa_out, swa_lse)
+        result = merge_attention_with_sink(merged_out, merged_lse, self.attn_sink)
+        output.copy_(result)
+
+    def _forward_sparse_mla_prefill_triton(
+        self,
+        q: torch.Tensor,
+        kv: torch.Tensor,
+        combined_indices: torch.Tensor,
+        combined_lens: torch.Tensor,
+        output: torch.Tensor,
+    ) -> None:
+        """Triton kernel path for prefill attention."""
+        from vllm.v1.attention.ops.triton_mla_utils import (
+            merge_attention_with_sink,
+        )
+        from vllm.v1.attention.ops.triton_sparse_mla_kernel import (
+            triton_sparse_mla_attention,
+        )
+
+        D = q.shape[-1]
+        kv_flat = kv.reshape(-1, 1, D)  # [seq_kv, 1, D]
+
+        # combined_indices: [num_tokens, topk] -> [num_tokens, 1, topk]
+        indices = combined_indices.unsqueeze(1).to(torch.int32)
+
+        # Pad topk to multiple of 16
+        topk = indices.shape[-1]
+        pad = (16 - topk % 16) % 16
+        if pad > 0:
+            pad_idx = torch.full(
+                (indices.shape[0], 1, pad), -1,
+                dtype=torch.int32, device=q.device,
+            )
+            indices = torch.cat([indices, pad_idx], dim=-1)
+
+        triton_out, triton_lse = triton_sparse_mla_attention(
+            q=q,
+            kv=kv_flat,
+            indices=indices,
+            sm_scale=self.scale,
+            topk_length=combined_lens,
+            return_lse=True,
+        )
+
+        result = merge_attention_with_sink(triton_out, triton_lse, self.attn_sink)
+        output.copy_(result)
+
     def _forward_sparse_mla_swa_decode_reference(
         self,
         q: torch.Tensor,
@@ -1359,29 +1606,50 @@ class DeepseekV4MLAAttention(nn.Module, AttentionLayerBase):
         )
 
         if _is_sparse_mla_reference_attention_enabled(q.device):
+            _use_triton = _is_triton_mla_enabled()
             if swa_only:
-                self._forward_sparse_mla_swa_decode_reference(
-                    q=q,
-                    swa_k_cache=self.swa_cache_layer.kv_cache,
-                    swa_metadata=swa_metadata,
-                    output=output,
-                )
+                if _use_triton:
+                    self._forward_sparse_mla_swa_decode_triton(
+                        q=q,
+                        swa_k_cache=self.swa_cache_layer.kv_cache,
+                        swa_metadata=swa_metadata,
+                        output=output,
+                    )
+                else:
+                    self._forward_sparse_mla_swa_decode_reference(
+                        q=q,
+                        swa_k_cache=self.swa_cache_layer.kv_cache,
+                        swa_metadata=swa_metadata,
+                        output=output,
+                    )
                 return
             if self.compress_ratio in (4, 128):
                 assert compressed_k_cache is not None
                 assert attn_metadata is not None
                 assert topk_indices is not None
                 assert topk_lens is not None
-                self._forward_sparse_mla_compressed_decode_reference(
-                    q=q,
-                    compressed_k_cache=compressed_k_cache,
-                    swa_k_cache=self.swa_cache_layer.kv_cache,
-                    topk_indices=topk_indices,
-                    topk_lens=topk_lens,
-                    swa_metadata=swa_metadata,
-                    attn_metadata=attn_metadata,
-                    output=output,
-                )
+                if _use_triton:
+                    self._forward_sparse_mla_compressed_decode_triton(
+                        q=q,
+                        compressed_k_cache=compressed_k_cache,
+                        swa_k_cache=self.swa_cache_layer.kv_cache,
+                        topk_indices=topk_indices,
+                        topk_lens=topk_lens,
+                        swa_metadata=swa_metadata,
+                        attn_metadata=attn_metadata,
+                        output=output,
+                    )
+                else:
+                    self._forward_sparse_mla_compressed_decode_reference(
+                        q=q,
+                        compressed_k_cache=compressed_k_cache,
+                        swa_k_cache=self.swa_cache_layer.kv_cache,
+                        topk_indices=topk_indices,
+                        topk_lens=topk_lens,
+                        swa_metadata=swa_metadata,
+                        attn_metadata=attn_metadata,
+                        output=output,
+                    )
                 return
             _dump_sparse_mla_attention_state(
                 phase="decode_unsupported_compressed",
@@ -1569,13 +1837,22 @@ class DeepseekV4MLAAttention(nn.Module, AttentionLayerBase):
                 )
 
             if _is_sparse_mla_reference_attention_enabled(q.device):
-                self._forward_sparse_mla_prefill_reference(
-                    q=q[query_start:query_end],
-                    kv=kv[:chunk_size],
-                    combined_indices=combined_indices,
-                    combined_lens=combined_lens,
-                    output=output[query_start:query_end],
-                )
+                if _is_triton_mla_enabled():
+                    self._forward_sparse_mla_prefill_triton(
+                        q=q[query_start:query_end],
+                        kv=kv[:chunk_size],
+                        combined_indices=combined_indices,
+                        combined_lens=combined_lens,
+                        output=output[query_start:query_end],
+                    )
+                else:
+                    self._forward_sparse_mla_prefill_reference(
+                        q=q[query_start:query_end],
+                        kv=kv[:chunk_size],
+                        combined_indices=combined_indices,
+                        combined_lens=combined_lens,
+                        output=output[query_start:query_end],
+                    )
                 continue
 
             output_chunk, _, _ = flash_mla_sparse_fwd(

--- a/vllm/model_executor/models/deepseek_v4.py
+++ b/vllm/model_executor/models/deepseek_v4.py
@@ -3,7 +3,7 @@
 import typing
 from collections.abc import Callable, Iterable
 from itertools import islice
-
+import os
 import regex as re
 import torch
 import torch.nn as nn
@@ -576,7 +576,7 @@ class DeepseekV4Model(nn.Module):
             )
         else:
             self.embed_tokens = PPMissingLayer()
-
+        config.num_hidden_layers = int(os.environ.get("VLLM_NUM_HIDDEN_LAYERS", config.num_hidden_layers))
         self.start_layer, self.end_layer, self.layers = make_layers(
             config.num_hidden_layers,
             lambda prefix: DeepseekV4DecoderLayer(
@@ -709,7 +709,8 @@ class DeepseekV4Model(nn.Module):
                 name = name.replace(weight_name, param_name)
                 if is_pp_missing_parameter(name, self):
                     break
-
+                if name not in params_dict:
+                    continue
                 param = params_dict[name]
                 weight_loader = param.weight_loader
                 weight_loader(param, loaded_weight, shard_id)
@@ -735,6 +736,8 @@ class DeepseekV4Model(nn.Module):
                         if is_pp_missing_parameter(name_mapped, self):
                             skip_expert_weight = True
                             break
+                        if name_mapped not in params_dict:
+                            continue
                         param = params_dict[name_mapped]
                         # We should ask the weight loader to return success or not
                         # here since otherwise we may skip experts with other
@@ -762,11 +765,15 @@ class DeepseekV4Model(nn.Module):
                         continue
                     narrow_weight = loaded_weight[head_rank_start:head_rank_end]
                     n = narrow_weight.shape[0]
+                    if name not in params_dict:
+                        continue
                     params_dict[name][:n].copy_(narrow_weight)
                     loaded_params.add(name)
                     continue
                 else:
                     if is_pp_missing_parameter(name, self):
+                        continue
+                    if name not in params_dict:
                         continue
                     param = params_dict[name]
                     weight_loader = getattr(

--- a/vllm/utils/deep_gemm.py
+++ b/vllm/utils/deep_gemm.py
@@ -20,6 +20,7 @@ from vllm.model_executor.layers.quantization.utils.quant_utils import (
     get_fp8_min_max,
 )
 from vllm.platforms import current_platform
+import vllm.utils.deep_gemm_torch_ref as dg_torch_ref
 from vllm.utils.import_utils import has_deep_gemm
 from vllm.utils.math_utils import cdiv
 
@@ -298,6 +299,8 @@ def fp8_gemm_nt(*args, **kwargs):
 
 
 def fp8_einsum(*args, **kwargs):
+    if envs.VLLM_SM120_DISABLE_DEEPGEMM:
+        return dg_torch_ref.fp8_einsum_torch_reference(*args, **kwargs)
     _lazy_init()
     if _fp8_einsum_impl is None:
         return _missing(*args, **kwargs)
@@ -340,47 +343,6 @@ def transform_sf_into_required_layout(*args, **kwargs):
     )
 
 
-def _fp8_mqa_logits_torch_reference(
-    q: tuple[torch.Tensor, torch.Tensor | None],
-    kv: tuple[torch.Tensor, torch.Tensor],
-    weights: torch.Tensor,
-    cu_seqlen_ks: torch.Tensor,
-    cu_seqlen_ke: torch.Tensor,
-    clean_logits: bool,
-) -> torch.Tensor:
-    q_values, q_scale = q
-    if q_scale is not None:
-        raise NotImplementedError("SM120 MQA logits fallback only supports FP8 Q")
-
-    k_values, k_scales = kv
-    q_f32 = q_values.to(torch.float32)
-    k_f32 = k_values.to(torch.float32) * k_scales.reshape(-1, 1).to(torch.float32)
-    k_t = k_f32.transpose(0, 1).contiguous()
-
-    seq_len, num_heads, _ = q_f32.shape
-    seq_len_kv = k_f32.shape[0]
-    logits = torch.zeros(
-        (seq_len, seq_len_kv), device=q_values.device, dtype=torch.float32
-    )
-
-    # Avoid materializing the full [H, M, N] score tensor for all heads.
-    for head_start in range(0, num_heads, 8):
-        head_end = min(head_start + 8, num_heads)
-        q_chunk = q_f32[:, head_start:head_end, :].transpose(0, 1).contiguous()
-        scores = torch.matmul(q_chunk, k_t)
-        head_weights = weights[:, head_start:head_end].transpose(0, 1).unsqueeze(-1)
-        logits += (scores.relu() * head_weights).sum(dim=0)
-
-    if clean_logits:
-        offsets = torch.arange(seq_len_kv, device=q_values.device)
-        valid = (offsets[None, :] >= cu_seqlen_ks[:, None]) & (
-            offsets[None, :] < cu_seqlen_ke[:, None]
-        )
-        logits = logits.masked_fill(~valid, float("-inf"))
-
-    return logits
-
-
 def fp8_fp4_mqa_logits(
     q: tuple[torch.Tensor, torch.Tensor | None],
     kv: tuple[torch.Tensor, torch.Tensor],
@@ -415,7 +377,7 @@ def fp8_fp4_mqa_logits(
     """
     _lazy_init()
     if current_platform.is_device_capability_family(120) and q[1] is None:
-        return _fp8_mqa_logits_torch_reference(
+        return dg_torch_ref.fp8_mqa_logits_torch_reference(
             q, kv, weights, cu_seqlen_ks, cu_seqlen_ke, clean_logits
         )
     if _fp8_fp4_mqa_logits_impl is None:
@@ -490,6 +452,16 @@ def fp8_fp4_paged_mqa_logits(
         `torch.float32`.
     """
     _lazy_init()
+    if envs.VLLM_SM120_DISABLE_DEEPGEMM:
+        return dg_torch_ref.fp8_paged_mqa_logits_torch_reference(
+            q,
+            kv_cache,
+            weights,
+            context_lens,
+            block_tables,
+            max_model_len,
+            clean_logits,
+        )
     if _fp8_fp4_paged_mqa_logits_impl is None:
         return _missing()
     return _fp8_fp4_paged_mqa_logits_impl(
@@ -518,6 +490,10 @@ def tf32_hc_prenorm_gemm(
 
     See the caller function for shape requirement
     """
+    if envs.VLLM_SM120_DISABLE_DEEPGEMM:
+        return dg_torch_ref.tf32_hc_prenorm_gemm_torch_reference(
+            x, fn, out, sqrsum, num_split
+        )
     _lazy_init()
     if _tf32_hc_prenorm_gemm_impl is None:
         return _missing()

--- a/vllm/utils/deep_gemm_torch_ref.py
+++ b/vllm/utils/deep_gemm_torch_ref.py
@@ -1,0 +1,256 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Torch reference implementations for DeepGEMM kernels.
+
+These are used as fallbacks on platforms where DeepGEMM native kernels
+are not available (e.g., SM120 Blackwell consumer GPUs).
+They are functionally correct but significantly slower than the native kernels.
+"""
+
+import torch
+
+from vllm.utils.math_utils import cdiv
+
+__all__ = [
+    "fp8_einsum_torch_reference",
+    "fp8_mqa_logits_torch_reference",
+    "fp8_paged_mqa_logits_torch_reference",
+    "tf32_hc_prenorm_gemm_torch_reference",
+]
+
+
+def fp8_einsum_torch_reference(
+    equation: str,
+    a_tuple: tuple[torch.Tensor, torch.Tensor],
+    b_tuple: tuple[torch.Tensor, torch.Tensor],
+    out: torch.Tensor,
+    recipe: tuple[int, ...] = (),
+) -> None:
+    """Torch fallback for fp8_einsum on SM120.
+
+    Dequantizes FP8 inputs to float32 and runs torch.einsum.
+    Scale tensors are per-token for `a` and per-block-128 for `b`.
+    """
+    a, a_scale = a_tuple
+    b, b_scale = b_tuple
+
+    # Dequant a: a is FP8 with per-token scales (last dim groups of 128)
+    a_f = a.to(torch.float32)
+    if a_scale is not None and a_scale.numel() > 0:
+        # a_scale shape matches a but with last dim // 128
+        # Repeat scale to match a's last dim
+        repeat_factor = a.shape[-1] // max(a_scale.shape[-1], 1)
+        if repeat_factor > 1:
+            a_scale_expanded = a_scale.to(torch.float32).repeat_interleave(
+                repeat_factor, dim=-1
+            )
+            # Trim if needed
+            a_scale_expanded = a_scale_expanded[..., : a.shape[-1]]
+            a_f = a_f * a_scale_expanded
+        else:
+            a_f = a_f * a_scale.to(torch.float32)
+
+    # Dequant b: b is FP8 with block scales
+    b_f = b.to(torch.float32)
+    if b_scale is not None and b_scale.numel() > 0:
+        if b_scale.dim() == b.dim():
+            # Per-block scales: repeat to match b dimensions
+            repeats = []
+            for i in range(b.dim()):
+                repeats.append(b.shape[i] // max(b_scale.shape[i], 1))
+            b_scale_expanded = b_scale.to(torch.float32).repeat_interleave(
+                repeats[-1], dim=-1
+            )
+            for i in range(b.dim() - 2, -1, -1):
+                if repeats[i] > 1:
+                    b_scale_expanded = b_scale_expanded.repeat_interleave(
+                        repeats[i], dim=i
+                    )
+            b_scale_expanded = b_scale_expanded[tuple(slice(0, s) for s in b.shape)]
+            b_f = b_f * b_scale_expanded
+        else:
+            b_f = b_f * b_scale.to(torch.float32)
+
+    result = torch.einsum(equation, a_f, b_f)
+    out.copy_(result.to(out.dtype))
+
+
+def fp8_mqa_logits_torch_reference(
+    q: tuple[torch.Tensor, torch.Tensor | None],
+    kv: tuple[torch.Tensor, torch.Tensor],
+    weights: torch.Tensor,
+    cu_seqlen_ks: torch.Tensor,
+    cu_seqlen_ke: torch.Tensor,
+    clean_logits: bool,
+) -> torch.Tensor:
+    """Torch fallback for fp8_fp4_mqa_logits on SM120."""
+    q_values, q_scale = q
+    if q_scale is not None:
+        raise NotImplementedError("SM120 MQA logits fallback only supports FP8 Q")
+
+    k_values, k_scales = kv
+    q_f32 = q_values.to(torch.float32)
+    k_f32 = k_values.to(torch.float32) * k_scales.reshape(-1, 1).to(torch.float32)
+    k_t = k_f32.transpose(0, 1).contiguous()
+
+    seq_len, num_heads, _ = q_f32.shape
+    seq_len_kv = k_f32.shape[0]
+    logits = torch.zeros(
+        (seq_len, seq_len_kv), device=q_values.device, dtype=torch.float32
+    )
+
+    # Avoid materializing the full [H, M, N] score tensor for all heads.
+    for head_start in range(0, num_heads, 8):
+        head_end = min(head_start + 8, num_heads)
+        q_chunk = q_f32[:, head_start:head_end, :].transpose(0, 1).contiguous()
+        scores = torch.matmul(q_chunk, k_t)
+        head_weights = weights[:, head_start:head_end].transpose(0, 1).unsqueeze(-1)
+        logits += (scores.relu() * head_weights).sum(dim=0)
+
+    if clean_logits:
+        offsets = torch.arange(seq_len_kv, device=q_values.device)
+        valid = (offsets[None, :] >= cu_seqlen_ks[:, None]) & (
+            offsets[None, :] < cu_seqlen_ke[:, None]
+        )
+        logits = logits.masked_fill(~valid, float("-inf"))
+
+    return logits
+
+
+def fp8_paged_mqa_logits_torch_reference(
+    q: tuple[torch.Tensor, torch.Tensor | None],
+    kv_cache: torch.Tensor,
+    weights: torch.Tensor,
+    context_lens: torch.Tensor,
+    block_tables: torch.Tensor,
+    max_model_len: int,
+    clean_logits: bool,
+) -> torch.Tensor:
+    """Torch fallback for fp8_fp4_paged_mqa_logits on SM120.
+
+    KV cache layout per block (written by indexer_k_quant_and_cache):
+      [block_size * head_dim FP8 bytes | block_size * 4 scale bytes]
+    The tensor shape [NB, block_size, 1, head_dim+4] is a stride trick;
+    bytes must be re-sliced flat per block.
+    """
+    q_values, q_scale = q
+    if q_scale is not None:
+        raise NotImplementedError("SM120 paged MQA logits fallback only supports FP8 Q")
+
+    batch_size, next_n, num_heads, head_dim = q_values.shape
+    if kv_cache.dim() == 4:
+        _, block_size, _, d_plus_4 = kv_cache.shape
+    else:
+        _, block_size, d_plus_4 = kv_cache.shape
+    num_blocks_total = kv_cache.shape[0]
+
+    # Flatten to [NB, block_size * (head_dim + 4)]
+    kv_flat = kv_cache.reshape(num_blocks_total, -1)
+    k_end = block_size * head_dim
+
+    q_f = q_values.to(torch.float32)  # [B, next_n, H, D]
+
+    logits = torch.full(
+        (batch_size * next_n, max_model_len),
+        float("-inf"),
+        device=q_values.device,
+        dtype=torch.float32,
+    )
+
+    # context_lens may be 2D [B, next_n] or [B, 1] or 1D [B]
+    if context_lens.dim() == 2:
+        ctx_lens_1d = context_lens.max(dim=1).values
+    else:
+        ctx_lens_1d = context_lens
+    ctx_lens_list = ctx_lens_1d.tolist()
+
+    if context_lens.dim() == 2:
+        ctx_lens_2d = context_lens.tolist()
+    else:
+        ctx_lens_2d = [[int(c)] * next_n for c in ctx_lens_list]
+
+    for i in range(batch_size):
+        context_len = int(ctx_lens_list[i])
+        if context_len <= 0:
+            continue
+
+        num_blocks = (context_len + block_size - 1) // block_size
+        block_idxs = block_tables[i, :num_blocks]  # [num_blocks]
+
+        # Gather blocks and decode FP8
+        blocks_flat = kv_flat[block_idxs]  # [num_blocks, block_size*(head_dim+4)]
+
+        # K data region: first block_size*head_dim bytes per block
+        k_data_u8 = blocks_flat[:, :k_end]  # [num_blocks, block_size*head_dim]
+        k_data = k_data_u8.reshape(num_blocks, block_size, head_dim)
+        k_fp8 = k_data.view(torch.float8_e4m3fn)
+        k_f = k_fp8.to(torch.float32)  # [num_blocks, block_size, head_dim]
+
+        # Scale region: last block_size*4 bytes per block
+        scale_u8 = blocks_flat[:, k_end:]  # [num_blocks, block_size*4]
+        k_scale = scale_u8.contiguous().view(torch.float32)  # [num_blocks, block_size]
+
+        # Apply scales
+        k_f = k_f * k_scale.unsqueeze(-1)  # [num_blocks, block_size, head_dim]
+
+        # Flatten to [total_tokens, head_dim]
+        total_tokens = num_blocks * block_size
+        kv_use = k_f.reshape(total_tokens, head_dim)
+
+        # q for this batch: [next_n, H, D]
+        q_batch = q_f[i]
+
+        # Compute scores per head chunk to save memory
+        batch_logits = torch.zeros(
+            (next_n, total_tokens),
+            device=q_values.device,
+            dtype=torch.float32,
+        )
+
+        for h_start in range(0, num_heads, 8):
+            h_end = min(h_start + 8, num_heads)
+            # q_chunk: [next_n, h_chunk, D] -> [h_chunk, next_n, D]
+            q_chunk = q_batch[:, h_start:h_end, :].transpose(0, 1).contiguous()
+            # scores: [h_chunk, next_n, total_tokens]
+            scores = torch.matmul(q_chunk, kv_use.t())
+            # weights for this batch
+            w = weights[i * next_n : (i + 1) * next_n, h_start:h_end].t().unsqueeze(-1)
+            batch_logits += (scores.relu() * w).sum(dim=0)
+
+        # Causal masking using per-token context lens
+        k_offsets = torch.arange(total_tokens, device=q_values.device)
+        for n in range(next_n):
+            q_ctx = int(ctx_lens_2d[i][min(n, len(ctx_lens_2d[i]) - 1)])
+            valid_mask = k_offsets < q_ctx
+            row = batch_logits[n].clone()
+            row[~valid_mask] = float("-inf")
+            logits[i * next_n + n, :total_tokens] = row
+
+    return logits
+
+
+def tf32_hc_prenorm_gemm_torch_reference(
+    x: torch.Tensor,
+    fn: torch.Tensor,
+    out: torch.Tensor,
+    sqrsum: torch.Tensor,
+    num_split: int,
+) -> None:
+    """Torch fallback for tf32_hc_prenorm_gemm on SM120.
+
+    DeepGEMM splits the K dimension into num_split chunks and stores
+    partial results in out[n_splits, M, N] and sqrsum[n_splits, M].
+    The downstream tilelang kernel sums across the split dimension.
+    """
+    x_f = x.float()  # [M, K]
+    # fn: [N, K], out: [n_splits, M, N], sqrsum: [n_splits, M]
+    K = x_f.shape[1]
+    chunk_size = cdiv(K, num_split)
+
+    for s in range(num_split):
+        k_start = s * chunk_size
+        k_end = min(k_start + chunk_size, K)
+        x_chunk = x_f[:, k_start:k_end]
+        fn_chunk = fn[:, k_start:k_end]
+        out[s].copy_(x_chunk @ fn_chunk.t())
+        sqrsum[s].copy_(x_chunk.square().sum(-1))

--- a/vllm/v1/attention/ops/mqa_logits_triton.py
+++ b/vllm/v1/attention/ops/mqa_logits_triton.py
@@ -1,0 +1,463 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Triton implementations of DeepGEMM's fp8_mqa_logits and
+fp8_paged_mqa_logits for GPUs where DeepGEMM is not available.
+
+The computation is:
+
+    Q, K                := dequant(Q_fp8), dequant(K_fp8) * k_scales
+    score[H, M, N]      = Q[M, H, D] @ K[N, D].T
+    logits[M, N]        = (relu(score) * weights[M, H]).sum(axis=0)
+    logits[M, N]       := -inf  outside of valid range
+
+Q/K are cast to bf16 for the matmul; the matmul uses an fp32 accumulator.
+
+K-side scale multiplication is done in fp32 before downcasting to bf16
+so the per-row dequant scale is applied at full precision.
+"""
+
+import torch
+
+from vllm.triton_utils import tl, triton
+
+# Paged decode config sweep. `num_warps=4` dominated in A100/SM80 bench
+# across {2,4,8}×{2,4}; the sub-optimal warps=2/8 picks were 1.5–1.7× slower
+# at the autotune key shape (num_heads=32, head_dim=128, block_size=64), and
+# autotune timing noise occasionally latched onto them. Keep only the two
+# `num_warps=4` configs so that path is always selected.
+_PAGED_AUTOTUNE_CONFIGS = [
+    triton.Config({}, num_warps=4, num_stages=ns) for ns in (2, 4)
+]
+
+# Prefill kernel adds BLOCK_N as a free tile axis along the K dimension.
+# Bench on A100/SM80 at (M=2048, N=8192, H=32, D=128) shows BN=32/64 with
+# num_warps∈{2,4} is within a few % of the best; BN=128 and num_warps=8 are
+# consistently ~1.5–3× worse. Trimming the sweep keeps the good configs and
+# shrinks first-call autotune time.
+_PREFILL_AUTOTUNE_CONFIGS = [
+    triton.Config({"BLOCK_N": bn}, num_warps=nw, num_stages=ns)
+    for bn in (32, 64)
+    for nw in (2, 4)
+    for ns in (2, 4)
+]
+
+
+@triton.jit
+def _decode_e4m3fn(u):
+    """Decode an E4M3FN byte (uint8) to fp32 using only uint/int/fp ops.
+
+    Triton on SM80 cannot compile `tl.float8e4nv`, so we never load the
+    FP8 dtype directly — we load uint8 and decode in software here. The
+    expansion is ~6 ops per element, dwarfed by the surrounding matmul.
+
+    E4M3FN: 1 sign + 4 exp (bias 7) + 3 mantissa.  No infinities.
+    Subnormal (exp=0): value = (-1)^s * (mant/8) * 2^(1 - 7)
+    Normal           : value = (-1)^s * (1 + mant/8) * 2^(exp - 7)
+    NaN at 0x7F/0xFF is decoded numerically as ±480 — sparse-MLA inputs
+    never hit this so the loss of NaN propagation is acceptable.
+    """
+    sign = u >> 7
+    exp_bits = ((u >> 3) & 0x0F).to(tl.int32)
+    mant = (u & 0x07).to(tl.int32)
+    is_normal = exp_bits != 0
+    sign_f = tl.where(sign != 0, -1.0, 1.0)
+    mant_f = tl.where(
+        is_normal,
+        (8 + mant).to(tl.float32) * 0.125,
+        mant.to(tl.float32) * 0.125,
+    )
+    # Subnormals: real exponent = 1 - bias.
+    eff_exp = tl.where(is_normal, exp_bits, 1)
+    factor = tl.exp2((eff_exp - 7).to(tl.float32))
+    return sign_f * mant_f * factor
+
+
+@triton.autotune(
+    configs=_PAGED_AUTOTUNE_CONFIGS,
+    key=["num_heads", "head_dim", "block_size"],
+)
+@triton.jit
+def _fp8_paged_mqa_logits_kernel(
+    q_ptr,
+    kv_fp8_ptr,
+    kv_scale_ptr,
+    weights_ptr,
+    context_lens_ptr,
+    block_tables_ptr,
+    logits_ptr,
+    stride_q_b,
+    stride_q_n,
+    stride_q_h,
+    stride_q_d,
+    stride_kvf_block,
+    stride_kvf_s,
+    stride_kvf_d,
+    stride_kvs_block,
+    stride_kvs_s,
+    stride_w_t,
+    stride_w_h,
+    stride_bt_b,
+    stride_bt_k,
+    stride_l_t,
+    stride_l_n,
+    next_n: tl.constexpr,
+    num_heads: tl.constexpr,
+    head_dim: tl.constexpr,
+    block_size: tl.constexpr,
+    BLOCK_H: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    token_id = tl.program_id(0)
+    block_rk = tl.program_id(1)
+
+    batch_id = token_id // next_n
+    next_n_id = token_id % next_n
+
+    context_len = tl.load(context_lens_ptr + batch_id)
+    if block_rk * block_size >= context_len:
+        return
+
+    q_offset = context_len - next_n + next_n_id
+
+    block_idx = tl.load(
+        block_tables_ptr + batch_id * stride_bt_b + block_rk * stride_bt_k
+    )
+
+    offs_h = tl.arange(0, BLOCK_H)
+    offs_d = tl.arange(0, BLOCK_D)
+    offs_n = tl.arange(0, BLOCK_N)
+    mask_h = offs_h < num_heads
+    mask_d = offs_d < head_dim
+    mask_n = offs_n < block_size
+
+    q_base = q_ptr + batch_id * stride_q_b + next_n_id * stride_q_n
+    q_byte = tl.load(
+        q_base + offs_h[:, None] * stride_q_h + offs_d[None, :] * stride_q_d,
+        mask=mask_h[:, None] & mask_d[None, :],
+        other=0,
+    )
+    q = _decode_e4m3fn(q_byte).to(tl.bfloat16)
+
+    kvf_base = kv_fp8_ptr + block_idx * stride_kvf_block
+    k_byte = tl.load(
+        kvf_base + offs_n[:, None] * stride_kvf_s + offs_d[None, :] * stride_kvf_d,
+        mask=mask_n[:, None] & mask_d[None, :],
+        other=0,
+    )
+    kvs_base = kv_scale_ptr + block_idx * stride_kvs_block
+    k_scale = tl.load(
+        kvs_base + offs_n * stride_kvs_s,
+        mask=mask_n,
+        other=0.0,
+    )
+    # Scale in fp32 for precision, then cast to bf16 for the matmul.
+    k = (_decode_e4m3fn(k_byte) * k_scale[:, None]).to(tl.bfloat16)
+
+    s = tl.dot(q, tl.trans(k))
+
+    w = tl.load(
+        weights_ptr + token_id * stride_w_t + offs_h * stride_w_h,
+        mask=mask_h,
+        other=0.0,
+    )
+    s = tl.where(s > 0, s, 0.0) * w[:, None]
+    out = tl.sum(s, axis=0)
+
+    k_offset = block_rk * block_size + offs_n
+    valid = mask_n & (k_offset < context_len) & (k_offset <= q_offset)
+    out = tl.where(valid, out, float("-inf"))
+
+    tl.store(
+        logits_ptr + token_id * stride_l_t + k_offset * stride_l_n,
+        out,
+        mask=mask_n,
+    )
+
+
+def fp8_paged_mqa_logits_triton(
+    q: torch.Tensor,
+    kv_cache: torch.Tensor,
+    weights: torch.Tensor,
+    context_lens: torch.Tensor,
+    block_tables: torch.Tensor,
+    max_model_len: int,
+) -> torch.Tensor:
+    """Triton implementation of DeepGEMM's fp8_paged_mqa_logits.
+
+    Args:
+        q:             [B, next_n, H, D] fp8_e4m3fn
+        kv_cache:      [num_blocks, block_size, 1, D+4] uint8 (FP8 + fp32 scale)
+        weights:       [B*next_n, H] float32
+        context_lens:  [B] int32
+        block_tables:  [B, max_blocks] int32
+    Returns:
+        logits:        [B*next_n, max_model_len] float32
+    """
+    B, next_n, num_heads, head_dim = q.shape
+    _, block_size, one, d_plus_4 = kv_cache.shape
+    assert one == 1
+    assert d_plus_4 == head_dim + 4
+
+    # Cache layout: `indexer_k_quant_and_cache` (csrc/cache_kernels.cu) writes
+    # each block as [K region | scale region] — all `block_size * head_dim`
+    # fp8 K bytes first, then `block_size * 4` fp32 scale bytes. The
+    # `[NB, block_size, 1, head_dim+4]` shape is just a stride trick; bytes
+    # must be re-sliced flat. The kernel decodes FP8 from uint8 manually since
+    # SM80 Triton can't compile the native fp8e4nv dtype.
+    num_blocks = kv_cache.shape[0]
+    kv_flat = kv_cache.view(num_blocks, -1)
+    k_end = block_size * head_dim
+    kv_byte = kv_flat[:, :k_end].as_strided(
+        (num_blocks, block_size, head_dim),
+        (kv_flat.stride(0), head_dim, 1),
+    )
+    kv_scale = kv_flat[:, k_end:].view(torch.float32)
+    q_byte = q.view(torch.uint8)
+
+    logits = torch.full(
+        (B * next_n, max_model_len),
+        float("-inf"),
+        dtype=torch.float32,
+        device=q.device,
+    )
+
+    BLOCK_H = max(16, triton.next_power_of_2(num_heads))
+    BLOCK_D = triton.next_power_of_2(head_dim)
+    BLOCK_N = triton.next_power_of_2(block_size)
+
+    grid = (B * next_n, block_tables.shape[1])
+    _fp8_paged_mqa_logits_kernel[grid](
+        q_byte,
+        kv_byte,
+        kv_scale,
+        weights,
+        context_lens,
+        block_tables,
+        logits,
+        q_byte.stride(0),
+        q_byte.stride(1),
+        q_byte.stride(2),
+        q_byte.stride(3),
+        kv_byte.stride(0),
+        kv_byte.stride(1),
+        kv_byte.stride(2),
+        kv_scale.stride(0),
+        kv_scale.stride(1),
+        weights.stride(0),
+        weights.stride(1),
+        block_tables.stride(0),
+        block_tables.stride(1),
+        logits.stride(0),
+        logits.stride(1),
+        next_n=next_n,
+        num_heads=num_heads,
+        head_dim=head_dim,
+        block_size=block_size,
+        BLOCK_H=BLOCK_H,
+        BLOCK_D=BLOCK_D,
+        BLOCK_N=BLOCK_N,
+    )
+    return logits
+
+
+@triton.autotune(
+    configs=_PREFILL_AUTOTUNE_CONFIGS,
+    # Per-program work doesn't depend on N — only the grid extent does — so
+    # a single autotune config is valid across seq lengths. Keeping N in the
+    # key used to re-tune from scratch on every new chunk size (e.g., 2048,
+    # 4096, 6144, 8192, 9993 for a 10K prompt with chunked prefill),
+    # producing ~2 minutes of first-call TTFT on top of the real work.
+    key=["num_heads", "head_dim"],
+)
+@triton.jit
+def _fp8_mqa_logits_kernel(
+    q_ptr,
+    k_ptr,
+    k_scale_ptr,
+    weights_ptr,
+    ks_ptr,
+    ke_ptr,
+    logits_ptr,
+    stride_q_m,
+    stride_q_h,
+    stride_q_d,
+    stride_k_n,
+    stride_k_d,
+    stride_w_m,
+    stride_w_h,
+    stride_l_m,
+    stride_l_n,
+    num_heads: tl.constexpr,
+    head_dim: tl.constexpr,
+    N: tl.constexpr,
+    BLOCK_H: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    m = tl.program_id(0)
+    n_block = tl.program_id(1)
+
+    n_start = n_block * BLOCK_N
+    offs_n = n_start + tl.arange(0, BLOCK_N)
+    mask_n = offs_n < N
+
+    offs_h = tl.arange(0, BLOCK_H)
+    offs_d = tl.arange(0, BLOCK_D)
+    mask_h = offs_h < num_heads
+    mask_d = offs_d < head_dim
+
+    q_byte = tl.load(
+        q_ptr
+        + m * stride_q_m
+        + offs_h[:, None] * stride_q_h
+        + offs_d[None, :] * stride_q_d,
+        mask=mask_h[:, None] & mask_d[None, :],
+        other=0,
+    )
+    q = _decode_e4m3fn(q_byte).to(tl.bfloat16)
+
+    k_byte = tl.load(
+        k_ptr + offs_n[:, None] * stride_k_n + offs_d[None, :] * stride_k_d,
+        mask=mask_n[:, None] & mask_d[None, :],
+        other=0,
+    )
+    k_scale = tl.load(k_scale_ptr + offs_n, mask=mask_n, other=0.0)
+    # Scale in fp32 for precision, then cast to bf16 for the matmul.
+    k = (_decode_e4m3fn(k_byte) * k_scale[:, None]).to(tl.bfloat16)
+
+    s = tl.dot(q, tl.trans(k))
+
+    w = tl.load(
+        weights_ptr + m * stride_w_m + offs_h * stride_w_h,
+        mask=mask_h,
+        other=0.0,
+    )
+    s = tl.where(s > 0, s, 0.0) * w[:, None]
+    out = tl.sum(s, axis=0)
+
+    ks = tl.load(ks_ptr + m)
+    ke = tl.load(ke_ptr + m)
+    valid = mask_n & (offs_n >= ks) & (offs_n < ke)
+    out = tl.where(valid, out, float("-inf"))
+
+    tl.store(
+        logits_ptr + m * stride_l_m + offs_n * stride_l_n,
+        out,
+        mask=mask_n,
+    )
+
+
+def fp8_mqa_logits_triton(
+    q: torch.Tensor,
+    kv: tuple[torch.Tensor, torch.Tensor],
+    weights: torch.Tensor,
+    cu_seqlen_ks: torch.Tensor,
+    cu_seqlen_ke: torch.Tensor,
+) -> torch.Tensor:
+    """Triton implementation of DeepGEMM's fp8_mqa_logits.
+
+    Args:
+        q:            [M, H, D] fp8_e4m3fn
+        kv:           (k_fp8 [N, D], k_scales [N]) — fp8_e4m3fn, float32
+        weights:      [M, H] float32
+        cu_seqlen_ks: [M] int32
+        cu_seqlen_ke: [M] int32
+    Returns:
+        logits:       [M, N] float32
+    """
+    k_fp8, k_scales = kv
+    k_scales = k_scales.reshape(-1)
+
+    M, num_heads, head_dim = q.shape
+    N = k_fp8.shape[0]
+
+    logits = torch.full(
+        (M, N),
+        float("-inf"),
+        dtype=torch.float32,
+        device=q.device,
+    )
+
+    BLOCK_H = max(16, triton.next_power_of_2(num_heads))
+    BLOCK_D = triton.next_power_of_2(head_dim)
+
+    # Pass FP8 tensors as uint8 — kernel decodes E4M3FN bytes manually so it
+    # works on SM80 where Triton can't compile the native fp8e4nv dtype.
+    q_byte = q.view(torch.uint8)
+    k_byte = k_fp8.view(torch.uint8)
+
+    # Grid depends on the autotuned BLOCK_N.
+    grid = lambda meta: (M, triton.cdiv(N, meta["BLOCK_N"]))  # noqa: E731
+    _fp8_mqa_logits_kernel[grid](
+        q_byte,
+        k_byte,
+        k_scales,
+        weights,
+        cu_seqlen_ks,
+        cu_seqlen_ke,
+        logits,
+        q_byte.stride(0),
+        q_byte.stride(1),
+        q_byte.stride(2),
+        k_byte.stride(0),
+        k_byte.stride(1),
+        weights.stride(0),
+        weights.stride(1),
+        logits.stride(0),
+        logits.stride(1),
+        num_heads=num_heads,
+        head_dim=head_dim,
+        N=N,
+        BLOCK_H=BLOCK_H,
+        BLOCK_D=BLOCK_D,
+    )
+    return logits
+
+
+def warmup_fp8_mqa_logits_triton(
+    num_heads: int,
+    head_dim: int,
+    device: torch.device,
+) -> None:
+    """Prime the prefill `@triton.autotune` cache for the indexer's logits
+    kernel. Runs one shape matching the autotune key so that the first real
+    request does not pay the inline sweep + JIT cost (~5–8 s on A100 SM80).
+
+    N is not in the autotune key (removed so chunked-prefill doesn't re-tune
+    at every chunk size), so a single dummy N is enough. Pick N large enough
+    to exercise every BLOCK_N config in `_PREFILL_AUTOTUNE_CONFIGS`.
+    """
+    max_block_n = max(c.kwargs["BLOCK_N"] for c in _PREFILL_AUTOTUNE_CONFIGS)
+    n = max_block_n
+    q = torch.empty(1, num_heads, head_dim, dtype=torch.float8_e4m3fn, device=device)
+    k = torch.empty(n, head_dim, dtype=torch.float8_e4m3fn, device=device)
+    scales = torch.zeros(n, dtype=torch.float32, device=device)
+    weights = torch.zeros(1, num_heads, dtype=torch.float32, device=device)
+    ks = torch.zeros(1, dtype=torch.int32, device=device)
+    ke = torch.full((1,), n, dtype=torch.int32, device=device)
+    fp8_mqa_logits_triton(q, (k, scales), weights, ks, ke)
+
+
+def warmup_fp8_paged_mqa_logits_triton(
+    num_heads: int,
+    head_dim: int,
+    block_size: int,
+    device: torch.device,
+) -> None:
+    """Prime the paged-decode `@triton.autotune` cache for the indexer's
+    logits kernel (see `warmup_fp8_mqa_logits_triton` for rationale).
+    """
+    num_blocks = 2
+    q = torch.empty(
+        1, 1, num_heads, head_dim, dtype=torch.float8_e4m3fn, device=device
+    )
+    kv_cache = torch.zeros(
+        num_blocks, block_size, 1, head_dim + 4, dtype=torch.uint8, device=device
+    )
+    weights = torch.zeros(1, num_heads, dtype=torch.float32, device=device)
+    context_lens = torch.tensor([block_size], dtype=torch.int32, device=device)
+    block_tables = torch.zeros(1, 1, dtype=torch.int32, device=device)
+    fp8_paged_mqa_logits_triton(
+        q, kv_cache, weights, context_lens, block_tables, max_model_len=block_size
+    )

--- a/vllm/v1/attention/ops/triton_mla_utils.py
+++ b/vllm/v1/attention/ops/triton_mla_utils.py
@@ -1,0 +1,89 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Utilities for merging attention outputs with LSE (log-sum-exp) scores.
+
+Used to combine:
+1. Compressed (top-k) + SWA (sliding window) attention outputs
+2. Merged attention output with DeepSeek V4's learned attention sink bias
+"""
+
+import torch
+
+
+def lse_merge(
+    out1: torch.Tensor,
+    lse1: torch.Tensor,
+    out2: torch.Tensor,
+    lse2: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Merge two attention outputs using their LSE scores.
+
+    Args:
+        out1: [num_tokens, num_heads, dv] bf16 — first attention output
+        lse1: [num_tokens, num_heads] float32 — first LSE
+        out2: [num_tokens, num_heads, dv] bf16 — second attention output
+        lse2: [num_tokens, num_heads] float32 — second LSE
+
+    Returns:
+        merged_out: [num_tokens, num_heads, dv] bf16
+        merged_lse: [num_tokens, num_heads] float32
+    """
+    # Numerically stable merge via online softmax
+    merge_max = torch.maximum(lse1, lse2)
+    w1 = torch.exp(lse1 - merge_max)
+    w2 = torch.exp(lse2 - merge_max)
+    denom = w1 + w2
+
+    # Avoid 0/0 when both LSEs are -inf (no valid KV tokens)
+    denom = torch.where(denom > 0, denom, torch.ones_like(denom))
+
+    merged_out = (
+        out1.float() * w1.unsqueeze(-1) + out2.float() * w2.unsqueeze(-1)
+    ) / denom.unsqueeze(-1)
+    merged_lse = merge_max + torch.log(denom)
+
+    return merged_out.to(out1.dtype), merged_lse
+
+
+def merge_attention_with_sink(
+    out: torch.Tensor,
+    lse: torch.Tensor,
+    attn_sink: torch.Tensor,
+) -> torch.Tensor:
+    """Merge attention output with DeepSeek V4's learned attention sink bias.
+
+    The attention sink is a per-head learned bias that acts as a baseline
+    attention score. It ensures DeepSeek V4's sink-aware denominator behavior
+    is preserved.
+
+    Formula:
+        merge_max = max(lse, attn_sink)
+        w_attn = exp(lse - merge_max)
+        w_sink = exp(attn_sink - merge_max)
+        output = (out * w_attn) / (w_attn + w_sink)
+
+    Note: The sink contributes to the denominator but not the numerator
+    (it has no associated value vector — it just "absorbs" attention mass).
+
+    Args:
+        out:       [num_tokens, num_heads, dv] bf16 — attention output
+        lse:       [num_tokens, num_heads] float32 — attention LSE
+        attn_sink: [num_heads] float32 — learned per-head sink bias
+
+    Returns:
+        output: [num_tokens, num_heads, dv] bf16
+    """
+    # attn_sink: [H] -> [1, H] for broadcasting
+    sink = attn_sink.unsqueeze(0)  # [1, H]
+
+    merge_max = torch.maximum(lse, sink)
+    w_attn = torch.exp(lse - merge_max)
+    w_sink = torch.exp(sink - merge_max)
+    denom = w_attn + w_sink
+
+    # Avoid 0/0
+    denom = torch.where(denom > 0, denom, torch.ones_like(denom))
+
+    # Sink has no value vector, so only w_attn scales the output
+    result = out.float() * w_attn.unsqueeze(-1) / denom.unsqueeze(-1)
+    return result.to(out.dtype)

--- a/vllm/v1/attention/ops/triton_sparse_mla_kernel.py
+++ b/vllm/v1/attention/ops/triton_sparse_mla_kernel.py
@@ -1,0 +1,659 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Triton sparse MLA attention with split-KV for low-batch decode.
+
+Stage 1 runs the sparse attention over a contiguous slice of the topk
+axis (or the full axis when `num_kv_splits=1`) and writes a partial
+`(out/e_sum, lse)` tile to a mid buffer. Stage 2 merges the splits via
+online-softmax rescaling — pattern from `triton_decode_attention.py`.
+
+Extended from PR #38476 with:
+- LSE output for external merges (compressed+SWA, then sink)
+- topk_length support for per-token valid length masking
+"""
+
+import functools
+
+import torch
+
+from vllm.triton_utils import LOG2E, LOGE2, tl, triton
+from vllm.utils.platform_utils import num_compute_units
+
+# Sparse MLA shape constants.
+# V3.2/GLM-5: dim_qk=576 (512 nope + 64 PE), V4: dim_qk=512 (no separate PE).
+_BLOCK_DMODEL = 512
+_BLOCK_DPE = 64  # Must be >0 for tl.arange; guarded by HAS_PE constexpr.
+_BLOCK_DV = 512
+_DIM_QK_V3 = _BLOCK_DMODEL + _BLOCK_DPE  # 576
+_DIM_QK_V4 = _BLOCK_DMODEL  # 512
+_SUPPORTED_DIM_QK = {_DIM_QK_V3, _DIM_QK_V4}
+
+_BLOCK_H = 16
+# Smallest BLOCK_N the autotune sweep offers; only used for the topk-divisibility
+# check at dispatch time.
+_MIN_BLOCK_N = 16
+
+# Merge kernel is launch-bound on a (1, 1) grid — one CTA per token starves the
+# SMs. Spread across heads and DV tiles (pattern from FlashMLA's combine kernel
+# at FlashMLA/csrc/smxx/decode/combine/combine.cu:22-27). BLOCK_H=1 so each
+# of the 8 per-rank heads runs concurrently; BLOCK_DV_TILE=128 splits the 512
+# output lanes into 4 tiles.
+_MERGE_BLOCK_H = 1
+_MERGE_BLOCK_DV_TILE = 128
+assert _BLOCK_DV % _MERGE_BLOCK_DV_TILE == 0
+_NUM_MERGE_DV_TILES = _BLOCK_DV // _MERGE_BLOCK_DV_TILE
+
+# Separate config sweeps for the single-pass (prefill) and split-KV (decode)
+# entry points. Per A100/SM80 sweeps:
+#   - Single-pass ("final") kernel at prefill M>>1 prefers BLOCK_N=16 with few
+#     warps; the wider configs in the combined sweep were landing 1.3–1.5×
+#     slower because autotune's key omits M and the cached pick was a bad
+#     compromise.
+#   - Split kernel at decode M=1 prefers BLOCK_N=32/num_warps=4 across every
+#     split count we tested.
+# Each kernel only ever runs in its own regime (see `_choose_num_kv_splits`),
+# so we can tune each independently.
+_FINAL_AUTOTUNE_CONFIGS = [
+    triton.Config({"BLOCK_N": 16}, num_warps=nw, num_stages=ns)
+    for nw in (2, 4)
+    for ns in (2, 4)
+]
+_SPLIT_AUTOTUNE_CONFIGS = [
+    triton.Config({"BLOCK_N": 32}, num_warps=4, num_stages=ns) for ns in (2, 4)
+]
+
+# Split count candidates that `_choose_num_kv_splits` can return; also the set
+# `_warmup_autotune` pre-compiles so the first decode does not pay the sweep cost.
+KV_SPLITS_CANDIDATES = (1, 2, 4, 8, 16)
+
+# Split-KV heuristic tuning.
+# At topk=2048 (DSv3.2/GLM-5.1) this unlocks 16-way split for decode, which
+# benches ~1.3× faster than 8-way on A100 SM80 at BLOCK_N=32/num_warps=4.
+_MIN_TOPK_PER_SPLIT = 128  # below this, per-split work is too small to amortize
+_SPLIT_MAX_OCCUPANCY = 4  # skip split when baseline grid fills >=1/4 of SMs
+
+
+@triton.jit
+def _sparse_mla_compute_tile(
+    q_buffer,
+    k_buffer,  # V is the first BLOCK_DV lanes of each row of k_buffer.
+    indices_ptr,
+    topk_length_ptr,  # [num_tokens] int32 or None; per-token valid index count
+    cur_q,
+    cur_head,
+    cur_kv_head_id,
+    mask_h,
+    split_start,
+    split_end,
+    seq_kv,
+    stride_q_token,
+    stride_q_head,
+    stride_kv_token,
+    stride_kv_head,
+    stride_indices_token,
+    stride_indices_head,
+    sm_scale,
+    HAS_TOPK_LENGTH: tl.constexpr,
+    HAS_PE: tl.constexpr,
+    BLOCK_H: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_DV: tl.constexpr,
+    BLOCK_DMODEL: tl.constexpr,
+    BLOCK_DPE: tl.constexpr,
+):
+    """Shared stage-1 body: load Q, run the sparse online-softmax loop over
+    `[split_start, split_end)` of the topk axis, return accumulators."""
+    offs_d = tl.arange(0, BLOCK_DMODEL)
+    offs_dv = tl.arange(0, BLOCK_DV)
+
+    if HAS_PE:
+        offs_dpe = BLOCK_DMODEL + tl.arange(0, BLOCK_DPE)
+        mask_dpe = offs_dpe < BLOCK_DMODEL + BLOCK_DPE
+
+    q = tl.load(
+        q_buffer
+        + cur_q * stride_q_token
+        + cur_head[:, None] * stride_q_head
+        + offs_d[None, :],
+        mask=mask_h[:, None],
+        other=0.0,
+    )
+    if HAS_PE:
+        qpe = tl.load(
+            q_buffer
+            + cur_q * stride_q_token
+            + cur_head[:, None] * stride_q_head
+            + offs_dpe[None, :],
+            mask=(mask_h[:, None]) & (mask_dpe[None, :]),
+            other=0.0,
+        )
+
+    # Load per-token valid length if provided
+    if HAS_TOPK_LENGTH:
+        token_topk_len = tl.load(topk_length_ptr + cur_q)
+    else:
+        token_topk_len = split_end  # effectively no limit
+
+    # Large negative but finite sentinel for masked-out positions. `-inf`
+    # would give `-inf - -inf = NaN` when a whole BLOCK_N tile is masked
+    # (common in short prefill where most topk slots are -1); a finite value
+    # keeps `sentinel - sentinel = 0` and `exp2(0) = 1`, and the
+    # corresponding v slots are already loaded as 0.
+    NEG_LARGE = -1.0e30
+    e_max = tl.zeros([BLOCK_H], dtype=tl.float32) + NEG_LARGE
+    e_sum = tl.zeros([BLOCK_H], dtype=tl.float32)
+    acc = tl.zeros([BLOCK_H, BLOCK_DV], dtype=tl.float32)
+
+    for start_indice in range(split_start, split_end, BLOCK_N):
+        offs_indice = start_indice + tl.arange(0, BLOCK_N)
+        mask_indice = offs_indice < split_end
+        # Apply topk_length mask: only indices < token_topk_len are valid
+        if HAS_TOPK_LENGTH:
+            mask_indice = mask_indice & (offs_indice < token_topk_len)
+        indices = tl.load(
+            indices_ptr
+            + cur_q * stride_indices_token
+            + cur_kv_head_id * stride_indices_head
+            + offs_indice,
+            mask=mask_indice,
+            other=-1,
+        )
+        mask_kv = (indices >= 0) & (indices < seq_kv)
+
+        offs_k = (
+            indices[None, :] * stride_kv_token
+            + cur_kv_head_id * stride_kv_head
+            + offs_d[:, None]
+        )
+        k = tl.load(k_buffer + offs_k, mask=mask_kv[None, :], other=0.0)
+        qk = tl.dot(q, k.to(q.dtype))
+
+        if HAS_PE:
+            offs_kpe = (
+                indices[None, :] * stride_kv_token
+                + cur_kv_head_id * stride_kv_head
+                + offs_dpe[:, None]
+            )
+            kpe = tl.load(
+                k_buffer + offs_kpe,
+                mask=(mask_kv[None, :]) & (mask_dpe[:, None]),
+                other=0.0,
+            )
+            qk += tl.dot(qpe, kpe.to(q.dtype))
+
+        qk *= sm_scale
+        qk = tl.where((mask_h[:, None]) & (mask_kv[None, :]), qk, NEG_LARGE)
+
+        offs_v = (
+            indices[:, None] * stride_kv_token
+            + cur_kv_head_id * stride_kv_head
+            + offs_dv[None, :]
+        )
+        v = tl.load(k_buffer + offs_v, mask=mask_kv[:, None], other=0.0)
+
+        n_e_max = tl.maximum(tl.max(qk, 1), e_max)
+        re_scale = tl.exp2(e_max - n_e_max)
+        p = tl.exp2(qk - n_e_max[:, None])
+        acc *= re_scale[:, None]
+        acc += tl.dot(p.to(v.dtype), v)
+        e_sum = e_sum * re_scale + tl.sum(p, 1)
+        e_max = n_e_max
+
+    return acc, e_max, e_sum
+
+
+@triton.autotune(configs=_FINAL_AUTOTUNE_CONFIGS, key=["index_topk", "kv_group_num"])
+@triton.jit
+def _sparse_mla_kernel_final(
+    q_buffer,
+    k_buffer,
+    indices_ptr,
+    out_ptr,
+    lse_ptr,  # [num_tokens, num_heads_q] float32, or null
+    topk_length_ptr,  # [num_tokens] int32, or null
+    seq_kv,
+    h_q,
+    stride_q_token,
+    stride_q_head,
+    stride_kv_token,
+    stride_kv_head,
+    stride_out_token,
+    stride_out_head,
+    stride_indices_token,
+    stride_indices_head,
+    sm_scale,
+    index_topk: tl.constexpr,
+    kv_group_num: tl.constexpr,
+    HAS_TOPK_LENGTH: tl.constexpr,
+    HAS_PE: tl.constexpr,
+    RETURN_LSE: tl.constexpr,
+    BLOCK_H: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_DV: tl.constexpr,
+    BLOCK_DMODEL: tl.constexpr,
+    BLOCK_DPE: tl.constexpr,
+    LOGE2: tl.constexpr,
+):
+    """Single-pass fast path: full topk, write final bf16 output directly."""
+    cur_q = tl.program_id(0)
+    cur_head_id = tl.program_id(1)
+    cur_kv_head_id = cur_head_id // tl.cdiv(kv_group_num, BLOCK_H)
+
+    VALID_BLOCK_H: tl.constexpr = BLOCK_H if kv_group_num > BLOCK_H else kv_group_num
+    cur_head = cur_head_id * VALID_BLOCK_H + tl.arange(0, BLOCK_H)
+    mask_h = (cur_head < (cur_head_id + 1) * VALID_BLOCK_H) & (cur_head < h_q)
+
+    acc, e_max, e_sum = _sparse_mla_compute_tile(
+        q_buffer,
+        k_buffer,
+        indices_ptr,
+        topk_length_ptr,
+        cur_q,
+        cur_head,
+        cur_kv_head_id,
+        mask_h,
+        0,
+        index_topk,
+        seq_kv,
+        stride_q_token,
+        stride_q_head,
+        stride_kv_token,
+        stride_kv_head,
+        stride_indices_token,
+        stride_indices_head,
+        sm_scale,
+        HAS_TOPK_LENGTH,
+        HAS_PE,
+        BLOCK_H,
+        BLOCK_N,
+        BLOCK_DV,
+        BLOCK_DMODEL,
+        BLOCK_DPE,
+    )
+
+    # Guard against queries with zero valid KV (e_sum == 0 → NaN from 0/0).
+    e_sum_safe = tl.where(e_sum > 0, e_sum, 1.0)
+    offs_dv = tl.arange(0, BLOCK_DV)
+    tl.store(
+        out_ptr
+        + cur_q * stride_out_token
+        + cur_head[:, None] * stride_out_head
+        + offs_dv[None, :],
+        (acc / e_sum_safe[:, None]).to(tl.bfloat16),
+        mask=mask_h[:, None],
+    )
+
+    # Write LSE = log(sum(exp(scores - max))) + max, in natural log
+    if RETURN_LSE:
+        lse_val = (e_max + tl.log2(e_sum_safe)) * LOGE2
+        tl.store(
+            lse_ptr + cur_q * h_q + cur_head,
+            lse_val,
+            mask=mask_h,
+        )
+
+
+@triton.autotune(
+    configs=_SPLIT_AUTOTUNE_CONFIGS,
+    key=["index_topk", "NUM_KV_SPLITS", "kv_group_num"],
+)
+@triton.jit
+def _sparse_mla_kernel_split(
+    q_buffer,
+    k_buffer,
+    indices_ptr,
+    mid_out_ptr,
+    topk_length_ptr,
+    seq_kv,
+    h_q,
+    stride_q_token,
+    stride_q_head,
+    stride_kv_token,
+    stride_kv_head,
+    stride_mid_token,
+    stride_mid_head,
+    stride_mid_split,
+    stride_indices_token,
+    stride_indices_head,
+    sm_scale,
+    index_topk: tl.constexpr,
+    NUM_KV_SPLITS: tl.constexpr,
+    kv_group_num: tl.constexpr,
+    HAS_TOPK_LENGTH: tl.constexpr,
+    HAS_PE: tl.constexpr,
+    BLOCK_H: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_DV: tl.constexpr,
+    BLOCK_DMODEL: tl.constexpr,
+    BLOCK_DPE: tl.constexpr,
+    LOGE2: tl.constexpr,
+):
+    """Stage 1 of split-KV: process one slice of the topk axis and write
+    its `(out_partial, lse_partial)` into the mid buffer."""
+    cur_q = tl.program_id(0)
+    cur_head_id = tl.program_id(1)
+    split_kv_id = tl.program_id(2)
+    cur_kv_head_id = cur_head_id // tl.cdiv(kv_group_num, BLOCK_H)
+
+    VALID_BLOCK_H: tl.constexpr = BLOCK_H if kv_group_num > BLOCK_H else kv_group_num
+    cur_head = cur_head_id * VALID_BLOCK_H + tl.arange(0, BLOCK_H)
+    mask_h = (cur_head < (cur_head_id + 1) * VALID_BLOCK_H) & (cur_head < h_q)
+
+    split_topk: tl.constexpr = tl.cdiv(index_topk, NUM_KV_SPLITS)
+    split_start = split_kv_id * split_topk
+    split_end = tl.minimum(split_start + split_topk, index_topk)
+
+    acc, e_max, e_sum = _sparse_mla_compute_tile(
+        q_buffer,
+        k_buffer,
+        indices_ptr,
+        topk_length_ptr,
+        cur_q,
+        cur_head,
+        cur_kv_head_id,
+        mask_h,
+        split_start,
+        split_end,
+        seq_kv,
+        stride_q_token,
+        stride_q_head,
+        stride_kv_token,
+        stride_kv_head,
+        stride_indices_token,
+        stride_indices_head,
+        sm_scale,
+        HAS_TOPK_LENGTH,
+        HAS_PE,
+        BLOCK_H,
+        BLOCK_N,
+        BLOCK_DV,
+        BLOCK_DMODEL,
+        BLOCK_DPE,
+    )
+
+    # Partial output and natural-log LSE for stage-2 merge.
+    e_sum_safe = tl.where(e_sum > 0, e_sum, 1.0)
+    offs_dv = tl.arange(0, BLOCK_DV)
+    mid_base_2d = (
+        mid_out_ptr
+        + cur_q * stride_mid_token
+        + cur_head[:, None] * stride_mid_head
+        + split_kv_id * stride_mid_split
+    )
+    tl.store(
+        mid_base_2d + offs_dv[None, :],
+        acc / e_sum_safe[:, None],
+        mask=mask_h[:, None],
+    )
+    mid_lse_ptr = (
+        mid_out_ptr
+        + cur_q * stride_mid_token
+        + cur_head * stride_mid_head
+        + split_kv_id * stride_mid_split
+        + BLOCK_DV
+    )
+    tl.store(mid_lse_ptr, (e_max + tl.log2(e_sum)) * LOGE2, mask=mask_h)
+
+
+@triton.jit
+def _sparse_mla_merge_kernel(
+    mid_out_ptr,
+    out_ptr,
+    lse_ptr,  # [num_tokens, num_heads_q] float32, or null
+    h_q,
+    stride_mid_token,
+    stride_mid_head,
+    stride_mid_split,
+    stride_out_token,
+    stride_out_head,
+    NUM_KV_SPLITS: tl.constexpr,
+    kv_group_num: tl.constexpr,
+    RETURN_LSE: tl.constexpr,
+    BLOCK_H: tl.constexpr,
+    BLOCK_DV: tl.constexpr,
+    BLOCK_DV_TILE: tl.constexpr,
+):
+    """Stage 2: N-way online-softmax merge of per-split `(out, lse)` tiles.
+
+    Grid is `(num_tokens, num_head_groups, num_dv_tiles)`. Each program handles
+    `BLOCK_H` heads × `BLOCK_DV_TILE` output-dim lanes. The LSE reduction is
+    identical across DV tiles for the same (token, head) — each program
+    recomputes it locally, which is cheap (O(NUM_KV_SPLITS) scalars) and
+    avoids inter-CTA synchronization.
+    """
+    cur_q = tl.program_id(0)
+    cur_head_id = tl.program_id(1)
+    cur_dv_tile = tl.program_id(2)
+
+    VALID_BLOCK_H: tl.constexpr = BLOCK_H if kv_group_num > BLOCK_H else kv_group_num
+    cur_head = cur_head_id * VALID_BLOCK_H + tl.arange(0, BLOCK_H)
+    mask_h = (cur_head < (cur_head_id + 1) * VALID_BLOCK_H) & (cur_head < h_q)
+
+    offs_dv = cur_dv_tile * BLOCK_DV_TILE + tl.arange(0, BLOCK_DV_TILE)
+    mask_dv = offs_dv < BLOCK_DV
+    e_max = tl.zeros([BLOCK_H], dtype=tl.float32) - float("inf")
+    e_sum = tl.zeros([BLOCK_H], dtype=tl.float32)
+    acc = tl.zeros([BLOCK_H, BLOCK_DV_TILE], dtype=tl.float32)
+
+    mid_base_2d = (
+        mid_out_ptr + cur_q * stride_mid_token + cur_head[:, None] * stride_mid_head
+    )
+    mid_lse_1d = (
+        mid_out_ptr + cur_q * stride_mid_token + cur_head * stride_mid_head + BLOCK_DV
+    )
+
+    for split_kv_id in range(NUM_KV_SPLITS):
+        tv = tl.load(
+            mid_base_2d + split_kv_id * stride_mid_split + offs_dv[None, :],
+            mask=mask_h[:, None] & mask_dv[None, :],
+            other=0.0,
+        )
+        tlogic = tl.load(
+            mid_lse_1d + split_kv_id * stride_mid_split,
+            mask=mask_h,
+            other=-float("inf"),
+        )
+        n_e_max = tl.maximum(tlogic, e_max)
+        old_scale = tl.exp(e_max - n_e_max)
+        exp_logic = tl.exp(tlogic - n_e_max)
+        acc = acc * old_scale[:, None] + exp_logic[:, None] * tv
+        e_sum = e_sum * old_scale + exp_logic
+        e_max = n_e_max
+
+    e_sum_safe = tl.where(e_sum > 0, e_sum, 1.0)
+    tl.store(
+        out_ptr
+        + cur_q * stride_out_token
+        + cur_head[:, None] * stride_out_head
+        + offs_dv[None, :],
+        (acc / e_sum_safe[:, None]).to(tl.bfloat16),
+        mask=mask_h[:, None] & mask_dv[None, :],
+    )
+
+    # Write merged LSE (only from dv_tile 0 to avoid duplicate writes)
+    if RETURN_LSE:
+        if cur_dv_tile == 0:
+            merged_lse = e_max + tl.log(e_sum_safe)
+            tl.store(
+                lse_ptr + cur_q * h_q + cur_head,
+                merged_lse,
+                mask=mask_h,
+            )
+
+
+@functools.lru_cache(maxsize=256)
+def _choose_num_kv_splits(
+    num_tokens: int, num_head_groups: int, index_topk: int, sm_count: int
+) -> int:
+    """Pick a power-of-2 split count that fills the device without dropping
+    per-split work below _MIN_TOPK_PER_SPLIT. Returns 1 when the single-pass
+    grid already reaches ~1/_SPLIT_MAX_OCCUPANCY utilization.
+    """
+    baseline = num_tokens * num_head_groups
+    if baseline == 0 or baseline * _SPLIT_MAX_OCCUPANCY >= sm_count:
+        return 1
+    ideal = triton.next_power_of_2(max(1, index_topk // _MIN_TOPK_PER_SPLIT))
+    max_splits = max(1, sm_count // baseline)
+    max_splits = 1 << (max_splits.bit_length() - 1)  # floor to power of 2
+    num_kv_splits = min(ideal, max_splits)
+    while num_kv_splits > 1 and index_topk % num_kv_splits != 0:
+        num_kv_splits //= 2
+    return max(1, num_kv_splits)
+
+
+def triton_sparse_mla_attention(
+    q: torch.Tensor,
+    kv: torch.Tensor,
+    indices: torch.Tensor,
+    sm_scale: float,
+    topk_length: torch.Tensor | None = None,
+    num_kv_splits: int | None = None,
+    sm_count: int | None = None,
+    return_lse: bool = False,
+) -> tuple[torch.Tensor, torch.Tensor | None]:
+    """Sparse MLA attention over topk indices.
+
+    Args:
+        q:         [num_tokens, num_heads_q, dim_qk] bf16
+        kv:        [seq_kv, num_heads_kv=1, dim_qk] bf16
+        indices:   [num_tokens, num_heads_kv=1, topk] int32
+        sm_scale:  softmax scale
+        topk_length: [num_tokens] int32, per-token valid index count.
+            If None, all indices are considered valid (masked only by >= 0).
+        num_kv_splits: override auto-heuristic; None/0 = auto, 1 = force
+            single-pass.
+        sm_count:  device SM count, used by the split heuristic. If None,
+            queried from the device.
+        return_lse: if True, also return per-head LSE for external merges.
+
+    Returns:
+        out:   [num_tokens, num_heads_q, _BLOCK_DV] bf16
+        lse:   [num_tokens, num_heads_q] float32 (only if return_lse=True,
+               else None)
+    """
+    num_tokens, num_heads_q, dim_qk = q.shape
+    assert dim_qk in _SUPPORTED_DIM_QK, (
+        f"sparse MLA kernel requires dim_qk in {_SUPPORTED_DIM_QK}, got {dim_qk}"
+    )
+    assert kv.shape[1] == 1 and kv.shape[2] == dim_qk
+    has_pe = dim_qk == _DIM_QK_V3  # V3.2/GLM-5 has separate PE
+    index_topk = indices.shape[2]
+    assert index_topk % _MIN_BLOCK_N == 0, (
+        f"topk ({index_topk}) must be a multiple of the smallest autotune "
+        f"BLOCK_N ({_MIN_BLOCK_N})"
+    )
+
+    kv_group_num = num_heads_q
+    num_head_groups = triton.cdiv(num_heads_q, min(_BLOCK_H, kv_group_num))
+
+    if num_kv_splits is None or num_kv_splits == 0:
+        if sm_count is None:
+            sm_count = num_compute_units(q.device.index)
+        num_kv_splits = _choose_num_kv_splits(
+            num_tokens, num_head_groups, index_topk, sm_count
+        )
+
+    out = torch.empty(
+        (num_tokens, num_heads_q, _BLOCK_DV),
+        dtype=torch.bfloat16,
+        device=q.device,
+    )
+
+    lse = None
+    if return_lse:
+        lse = torch.empty(
+            (num_tokens, num_heads_q),
+            dtype=torch.float32,
+            device=q.device,
+        )
+
+    has_topk_length = topk_length is not None
+    topk_length_ptr = topk_length if has_topk_length else indices  # dummy
+
+    if num_kv_splits == 1:
+        _sparse_mla_kernel_final[(num_tokens, num_head_groups)](
+            q_buffer=q,
+            k_buffer=kv,
+            indices_ptr=indices,
+            out_ptr=out,
+            lse_ptr=lse if return_lse else out,  # dummy when not returning
+            topk_length_ptr=topk_length_ptr,
+            seq_kv=kv.shape[0],
+            h_q=num_heads_q,
+            stride_q_token=q.stride(0),
+            stride_q_head=q.stride(1),
+            stride_kv_token=kv.stride(0),
+            stride_kv_head=kv.stride(1),
+            stride_out_token=out.stride(0),
+            stride_out_head=out.stride(1),
+            stride_indices_token=indices.stride(0),
+            stride_indices_head=indices.stride(1),
+            sm_scale=sm_scale * LOG2E,
+            index_topk=index_topk,
+            kv_group_num=kv_group_num,
+            HAS_TOPK_LENGTH=has_topk_length,
+            HAS_PE=has_pe,
+            RETURN_LSE=return_lse,
+            BLOCK_H=_BLOCK_H,
+            BLOCK_DV=_BLOCK_DV,
+            BLOCK_DMODEL=_BLOCK_DMODEL,
+            BLOCK_DPE=_BLOCK_DPE,
+            LOGE2=LOGE2,
+        )
+        return out, lse
+
+    # Split-KV: partial fp32 output + LSE per (token, head, split).
+    mid_out = torch.empty(
+        (num_tokens, num_heads_q, num_kv_splits, _BLOCK_DV + 1),
+        dtype=torch.float32,
+        device=q.device,
+    )
+    _sparse_mla_kernel_split[(num_tokens, num_head_groups, num_kv_splits)](
+        q_buffer=q,
+        k_buffer=kv,
+        indices_ptr=indices,
+        mid_out_ptr=mid_out,
+        topk_length_ptr=topk_length_ptr,
+        seq_kv=kv.shape[0],
+        h_q=num_heads_q,
+        stride_q_token=q.stride(0),
+        stride_q_head=q.stride(1),
+        stride_kv_token=kv.stride(0),
+        stride_kv_head=kv.stride(1),
+        stride_mid_token=mid_out.stride(0),
+        stride_mid_head=mid_out.stride(1),
+        stride_mid_split=mid_out.stride(2),
+        stride_indices_token=indices.stride(0),
+        stride_indices_head=indices.stride(1),
+        sm_scale=sm_scale * LOG2E,
+        index_topk=index_topk,
+        NUM_KV_SPLITS=num_kv_splits,
+        kv_group_num=kv_group_num,
+        HAS_TOPK_LENGTH=has_topk_length,
+        HAS_PE=has_pe,
+        BLOCK_H=_BLOCK_H,
+        BLOCK_DV=_BLOCK_DV,
+        BLOCK_DMODEL=_BLOCK_DMODEL,
+        BLOCK_DPE=_BLOCK_DPE,
+        LOGE2=LOGE2,
+    )
+
+    _sparse_mla_merge_kernel[(num_tokens, num_heads_q, _NUM_MERGE_DV_TILES)](
+        mid_out_ptr=mid_out,
+        out_ptr=out,
+        lse_ptr=lse if return_lse else out,  # dummy when not returning
+        h_q=num_heads_q,
+        stride_mid_token=mid_out.stride(0),
+        stride_mid_head=mid_out.stride(1),
+        stride_mid_split=mid_out.stride(2),
+        stride_out_token=out.stride(0),
+        stride_out_head=out.stride(1),
+        NUM_KV_SPLITS=num_kv_splits,
+        kv_group_num=kv_group_num,
+        RETURN_LSE=return_lse,
+        BLOCK_H=_MERGE_BLOCK_H,
+        BLOCK_DV=_BLOCK_DV,
+        BLOCK_DV_TILE=_MERGE_BLOCK_DV_TILE,
+        num_warps=2,
+    )
+    return out, lse


### PR DESCRIPTION
# DeepSeek V4 Flash — DeepGEMM & Attention Support Matrix

## Function Support Across Deployment Scenarios

| Function | SM100/SM90 (Native) | SM120 (Torch + DeepGEMM Ref) | No DeepGEMM, No FlashMLA |
|----------|-------------------|-------------------------------|--------------------------|
| **FlashMLA Attention** | ✅ FlashMLA native kernel | ✅ Triton MLA kernels (`VLLM_SM120_TRITON_MLA=1`) | ⚠️ Torch reference attention (~2.5 tok/s) |
| **`fp8_gemm_nt`** | ✅ DeepGEMM native | ✅ CUTLASS/Triton fallback | ⚠️ CUTLASS/Triton fallback |
| **`fp8_m_grouped_gemm_nt`** | ✅ DeepGEMM native | ✅ MarlinMoE fallback | ⚠️ MarlinMoE fallback |
| **`fp8_einsum`** | ✅ DeepGEMM native | ✅ Torch reference (`_fp8_einsum_torch_reference`) | ⚠️ Torch reference (same) |
| **`fp8_fp4_mqa_logits`** | ✅ DeepGEMM native | ✅ Torch reference (`_fp8_mqa_logits_torch_reference`) | ⚠️ Torch reference (same) |
| **`fp8_fp4_paged_mqa_logits`** | ✅ DeepGEMM native | ✅ Torch reference (`_fp8_paged_mqa_logits_torch_reference`) | ⚠️ Torch reference (same) |
| **`tf32_hc_prenorm_gemm`** | ✅ DeepGEMM native | ✅ Torch reference (`_tf32_hc_prenorm_gemm_torch_reference`) | ⚠️ Torch reference (same) |

### Legend
- ✅ = Functional and performant
- ⚠️ = Functional but slower (Python/torch fallback)

## Scenario Details

### 1. SM100/SM90 (Native) — e.g., H100, B200
- All DeepGEMM kernels available natively
- FlashMLA provides optimized MLA attention
- Best performance path

### 2. SM120 (Torch + Ref Fallbacks) — e.g., RTX 6000D Blackwell
- DeepGEMM native kernels **not available** (arch check rejects SM120)
- FlashMLA **not available** (SM90/SM100 only)
- **Replacements implemented:**
  - FlashMLA → Triton MLA kernels (2.4x faster than torch reference)
  - `fp8_gemm_nt` / grouped variants → CUTLASS/MarlinMoE (already handled by vLLM)
  - `fp8_einsum` → torch dequant + `torch.einsum` with FP8 block scale broadcasting
  - `fp8_fp4_mqa_logits` → torch reference (pre-existing)
  - `fp8_fp4_paged_mqa_logits` → torch reference with paged KV cache gather + ReLU-weighted scoring
  - `tf32_hc_prenorm_gemm` → torch split-K matmul + sum-of-squares
- **Dispatch:** `current_platform.is_device_capability_family(120)` in `vllm/utils/deep_gemm.py`
- **Env vars required:** `VLLM_SM120_REFERENCE_DEEPSEEK_V4_ATTENTION=1`, `VLLM_SM120_TRITON_MLA=1`

### 3. No DeepGEMM, No FlashMLA — Generic fallback
- Same torch reference functions as SM120 scenario
- Triggered by `_missing()` → crash unless SM120 gate is hit
- **Not a supported deployment path** — exists only as safety net

## Performance (SM120, 4× RTX 6000D, TP=4, eager, FP8 KV cache)

| Config | Output tok/s | Input tok/s |
|--------|-------------|-------------|
| Torch reference attention only | ~2.5 | ~1.0 |
| Triton MLA + torch DeepGEMM fallbacks | ~14 | ~4.8 |
| Triton MLA + native DeepGEMM (future) | TBD | TBD |

## Implementation Files

| File | Purpose |
|------|---------|
| `vllm/utils/deep_gemm.py` | SM120 dispatch + all torch reference implementations |
| `vllm/v1/attention/ops/triton_sparse_mla_kernel.py` | Triton sparse MLA attention kernel |
| `vllm/v1/attention/ops/mqa_logits_triton.py` | Triton FP8 MQA logits for indexer |
| `vllm/v1/attention/ops/triton_mla_utils.py` | LSE merge + attention sink utilities |
| `vllm/model_executor/layers/deepseek_v4_attention.py` | Triton MLA routing logic |
| `vllm/envs.py` | `VLLM_SM120_TRITON_MLA` env var |



Port triton sparse MLA kernel from PR #38476 and extend it to fully support DeepSeek V4 attention:

- triton_sparse_mla_kernel.py: sparse MLA attention with split-KV, LSE output for external merges, topk_length masking, and HAS_PE flag to support both V3.2 (dim_qk=576) and V4 (dim_qk=512)
- mqa_logits_triton.py: FP8 MQA logits for the indexer with software E4M3 decode (works on any GPU arch including SM120)
- triton_mla_utils.py: LSE merge + attention sink merge utilities
- Wire triton paths into deepseek_v4_attention.py for prefill, SWA decode, and compressed+SWA decode, gated by VLLM_SM120_TRITON_MLA=1

Achieves ~2.4x speedup over torch reference (~6 tok/s vs ~2.5 tok/s) on 4xRTX6000D SM120 with DeepSeek-V4-Flash.

<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://docs.vllm.ai/en/latest/contributing>** (anything written below this line will be removed by GitHub Actions)
