### PR TITLE
[Attn][Triton] Support FP8 q_scale/k_scale/v_scale in per-tensor attention path

### DIFF
--- a/tests/kernels/attention/test_triton_unified_attention.py
+++ b/tests/kernels/attention/test_triton_unified_attention.py
@@ -224,6 +224,140 @@ def test_triton_unified_attn(
 
 
 @pytest.mark.parametrize(
+    "seq_lens", [[(1, 1328), (5, 18), (129, 463)], [(1, 523), (1, 37), (1, 2011)]]
+)
+@pytest.mark.parametrize("num_heads", [(4, 4), (8, 2)])
+@pytest.mark.parametrize("head_size", HEAD_SIZES)
+@pytest.mark.parametrize("block_size", BLOCK_SIZES)
+@pytest.mark.parametrize("num_blocks", [2048])
+@pytest.mark.parametrize("seq_threshold_3D", [0])
+@torch.inference_mode()
+def test_triton_unified_attn_fp8_q_scale_folding(
+    seq_lens: list[tuple[int, int]],
+    num_heads: tuple[int, int],
+    head_size: int,
+    block_size: int,
+    num_blocks: int,
+    seq_threshold_3D: int,
+) -> None:
+    """Verify that folding q_scale * k_scale into softmax_scale and applying
+    v_scale post-kernel produces correct results for FP8 per-tensor quant.
+
+    This mirrors the approach used in TritonAttentionImpl when Q is FP8 and
+    KV cache uses per-tensor FP8 quantization.
+    """
+    torch.set_default_device(DEVICE_TYPE)
+    set_random_seed(42)
+
+    num_seqs = len(seq_lens)
+    query_lens = [x[0] for x in seq_lens]
+    kv_lens = [x[1] for x in seq_lens]
+    num_query_heads, num_kv_heads = num_heads
+    max_query_len = max(query_lens)
+    max_kv_len = max(kv_lens)
+    window_size = (-1, -1)
+    base_scale = head_size**-0.5
+
+    # Non-trivial per-tensor scales.
+    q_scale = 0.73
+    k_scale = 1.42
+    v_scale = 0.91
+
+    # Generate bf16 reference tensors.
+    query_bf16 = torch.randn(
+        sum(query_lens), num_query_heads, head_size, dtype=torch.bfloat16
+    )
+    key_cache_bf16 = torch.randn(
+        num_blocks, block_size, num_kv_heads, head_size, dtype=torch.bfloat16
+    )
+    value_cache_bf16 = torch.randn_like(key_cache_bf16)
+
+    cu_query_lens = torch.tensor([0] + query_lens, dtype=torch.int32).cumsum(
+        dim=0, dtype=torch.int32
+    )
+    kv_lens_t = torch.tensor(kv_lens, dtype=torch.int32)
+    max_num_blocks_per_seq = (max_kv_len + block_size - 1) // block_size
+    block_tables = torch.randint(
+        0, num_blocks, (num_seqs, max_num_blocks_per_seq), dtype=torch.int32
+    )
+
+    # Quantize Q, K, V to FP8 (simulating what QuantFP8 + KV cache store do).
+    query_fp8 = (
+        (query_bf16.float() / q_scale)
+        .clamp(torch.finfo(FP8_DTYPE).min, torch.finfo(FP8_DTYPE).max)
+        .to(FP8_DTYPE)
+    )
+    key_cache_fp8 = (
+        (key_cache_bf16.float() / k_scale)
+        .clamp(torch.finfo(FP8_DTYPE).min, torch.finfo(FP8_DTYPE).max)
+        .to(FP8_DTYPE)
+    )
+    value_cache_fp8 = (
+        (value_cache_bf16.float() / v_scale)
+        .clamp(torch.finfo(FP8_DTYPE).min, torch.finfo(FP8_DTYPE).max)
+        .to(FP8_DTYPE)
+    )
+
+    # Fold q_scale * k_scale into softmax_scale (the TritonAttentionImpl approach).
+    effective_scale = base_scale * q_scale * k_scale
+
+    num_par_softmax_segments = 16
+    head_size_padded = next_power_of_2(head_size)
+    softmax_segm_output = torch.empty(
+        (seq_threshold_3D, num_query_heads, num_par_softmax_segments, head_size_padded),
+        dtype=torch.float32,
+    )
+    softmax_segm_max = torch.empty(
+        (seq_threshold_3D, num_query_heads, num_par_softmax_segments),
+        dtype=torch.float32,
+    )
+    softmax_segm_expsum = torch.empty(
+        (seq_threshold_3D, num_query_heads, num_par_softmax_segments),
+        dtype=torch.float32,
+    )
+
+    output = torch.empty_like(query_bf16)
+    unified_attention(
+        q=query_fp8,
+        k=key_cache_fp8,
+        v=value_cache_fp8,
+        out=output,
+        cu_seqlens_q=cu_query_lens,
+        seqused_k=kv_lens_t,
+        max_seqlen_q=max_query_len,
+        max_seqlen_k=max_kv_len,
+        softmax_scale=effective_scale,
+        causal=True,
+        window_size=window_size,
+        block_table=block_tables,
+        softcap=0,
+        q_descale=None,
+        k_descale=None,
+        v_descale=None,
+        seq_threshold_3D=seq_threshold_3D,
+        num_par_softmax_segments=num_par_softmax_segments,
+        softmax_segm_output=softmax_segm_output,
+        softmax_segm_max=softmax_segm_max,
+        softmax_segm_expsum=softmax_segm_expsum,
+    )
+    # Apply v_scale post-kernel.
+    output.mul_(v_scale)
+
+    # Reference: use original bf16 data with standard scale.
+    ref_output = ref_paged_attn(
+        query=query_bf16,
+        key_cache=key_cache_bf16,
+        value_cache=value_cache_bf16,
+        query_lens=query_lens,
+        kv_lens=kv_lens,
+        block_tables=block_tables,
+        scale=base_scale,
+    )
+    # FP8 quantization introduces noise; use relaxed tolerances.
+    torch.testing.assert_close(output, ref_output, atol=1.5e-1, rtol=1.5e-1)
+
+
+@pytest.mark.parametrize(
     "seq_lens",
     [
         [(1, 1328), (5, 18), (129, 463)],

--- a/vllm/v1/attention/backends/triton_attn.py
+++ b/vllm/v1/attention/backends/triton_attn.py
@@ -592,8 +592,10 @@ class TritonAttentionImpl(AttentionImpl):
         # FP8 per-tensor / auto path (original flow).
         else:
             key_cache, value_cache = kv_cache.unbind(1)
-            is_quantized = is_quantized_kv_cache(self.kv_cache_dtype)
-            if is_quantized and key_cache.dtype != self.fp8_dtype:
+            if (
+                is_quantized_kv_cache(self.kv_cache_dtype)
+                and key_cache.dtype != self.fp8_dtype
+            ):
                 key_cache = key_cache.view(self.fp8_dtype)
                 value_cache = value_cache.view(self.fp8_dtype)
             descale_shape = (
@@ -619,22 +621,20 @@ class TritonAttentionImpl(AttentionImpl):
 
         mm_prefix_range_tensor = attn_metadata.mm_prefix_range_tensor
 
-        # When Q is FP8 (quantized query) and KV cache is FP8 per-tensor,
-        # the kernel's _cast_kv_tile keeps K/V in FP8 for FP8 MMA and skips
-        # applying k_scale/v_scale.  We fold q_scale * k_scale into
-        # softmax_scale and apply v_scale to the output after the kernel,
-        # matching FlashInfer's strategy.
-        fp8_per_tensor = (
-            not self._is_per_token_head_quant
-            and is_quantized
-            and query.dtype == self.fp8_dtype
-        )
-        if fp8_per_tensor:
-            softmax_scale = self.scale * layer._q_scale_float * layer._k_scale_float
-            v_scale_float = layer._v_scale_float
-        else:
-            softmax_scale = self.scale
-            v_scale_float = 1.0
+        # When Q is FP8, the kernel does not support a separate q_descale
+        # parameter and assumes the query is already in the correct range.
+        # We fold q_scale into softmax_scale unconditionally.  Additionally,
+        # for the per-tensor FP8 path, _cast_kv_tile keeps K/V in FP8 for
+        # FP8 MMA and skips k_scale/v_scale — we fold k_scale into
+        # softmax_scale and apply v_scale post-kernel (FlashInfer strategy).
+        softmax_scale = self.scale
+        v_scale_float = 1.0
+        if query.dtype == self.fp8_dtype:
+            softmax_scale *= layer._q_scale_float
+            if not self._is_per_token_head_quant:
+                # Per-tensor path: kernel skips k/v descale for FP8 Q.
+                softmax_scale *= layer._k_scale_float
+                v_scale_float = layer._v_scale_float
 
         unified_attention(
             q=query[:num_actual_tokens],

--- a/vllm/v1/attention/backends/triton_attn.py
+++ b/vllm/v1/attention/backends/triton_attn.py
@@ -621,19 +621,20 @@ class TritonAttentionImpl(AttentionImpl):
 
         mm_prefix_range_tensor = attn_metadata.mm_prefix_range_tensor
 
-        # When Q is FP8, the kernel does not support a separate q_descale
-        # parameter and assumes the query is already in the correct range.
-        # We fold q_scale into softmax_scale unconditionally.  Additionally,
-        # for the per-tensor FP8 path, _cast_kv_tile keeps K/V in FP8 for
-        # FP8 MMA and skips k_scale/v_scale — we fold k_scale into
-        # softmax_scale and v_scale into output_scale (FlashInfer strategy).
+        # When Q is FP8 (quantized via QuantFP8 with a calibrated q_scale
+        # loaded from the checkpoint), the Triton kernel has no q_descale
+        # parameter — it performs FP8 MMA directly on Q.  We fold q_scale
+        # into softmax_scale so the dot-product result is correctly scaled.
         #
-        # NOTE: softmax_scale is a host-side scalar baked into the kernel
-        # launch.  For static quantization (scales loaded from disk), this
-        # is perfectly safe with CUDA Graphs since the value never changes.
-        # For dynamic calibration (calculate_kv_scales=True), scales
-        # stabilize during warmup before graph capture, matching
-        # FlashInfer's existing approach (bmm1_scale/bmm2_scale).
+        # For the per-tensor FP8 KV cache path, _cast_kv_tile also skips
+        # k_scale/v_scale when Q is FP8 (keeps K/V in FP8 for FP8 MMA).
+        # We fold k_scale into softmax_scale and handle v_scale via
+        # output_scale (FP8 output) or post-kernel mul (bf16 output).
+        # This matches FlashInfer's bmm1_scale/bmm2_scale strategy.
+        #
+        # These scales are static (loaded from disk or set once during
+        # warmup), so folding into a host-side scalar is safe with CUDA
+        # Graphs — the value is constant across all replays.
         is_quantized_per_tensor = (
             is_quantized_kv_cache(self.kv_cache_dtype)
             and not self._is_per_token_head_quant

--- a/vllm/v1/attention/backends/triton_attn.py
+++ b/vllm/v1/attention/backends/triton_attn.py
@@ -626,15 +626,35 @@ class TritonAttentionImpl(AttentionImpl):
         # We fold q_scale into softmax_scale unconditionally.  Additionally,
         # for the per-tensor FP8 path, _cast_kv_tile keeps K/V in FP8 for
         # FP8 MMA and skips k_scale/v_scale — we fold k_scale into
-        # softmax_scale and apply v_scale post-kernel (FlashInfer strategy).
+        # softmax_scale and v_scale into output_scale (FlashInfer strategy).
+        #
+        # NOTE: softmax_scale is a host-side scalar baked into the kernel
+        # launch. With CUDA Graphs + dynamic quantization, the captured
+        # graph will use the scale from capture time.  This matches
+        # FlashInfer's existing approach and is acceptable because scales
+        # stabilize during warmup before graph capture.
+        is_quantized_per_tensor = (
+            is_quantized_kv_cache(self.kv_cache_dtype)
+            and not self._is_per_token_head_quant
+        )
         softmax_scale = self.scale
         v_scale_float = 1.0
         if query.dtype == self.fp8_dtype:
+            # Always fold q_scale when Q is FP8: kernel has no q_descale.
             softmax_scale *= layer._q_scale_float
-            if not self._is_per_token_head_quant:
+            if is_quantized_per_tensor:
                 # Per-tensor path: kernel skips k/v descale for FP8 Q.
                 softmax_scale *= layer._k_scale_float
                 v_scale_float = layer._v_scale_float
+
+        # Fold v_scale into output_scale when output is FP8 (avoids crash
+        # from in-place mul_ on FP8 tensors and saves a memory pass).
+        # When output is bf16 (output_scale is None), apply post-kernel.
+        effective_output_scale = output_scale
+        if v_scale_float != 1.0 and output_scale is not None:
+            # Kernel does: acc * (1/output_scale).  We want:
+            # acc * v_scale * (1/output_scale) = acc * (1/(output_scale/v_scale))
+            effective_output_scale = output_scale / v_scale_float
 
         unified_attention(
             q=query[:num_actual_tokens],
@@ -661,7 +681,7 @@ class TritonAttentionImpl(AttentionImpl):
             softmax_segm_max=softmax_segm_max,
             softmax_segm_expsum=softmax_segm_expsum,
             sinks=self.sinks,
-            output_scale=output_scale,
+            output_scale=effective_output_scale,
             mm_prefix_range=mm_prefix_range_tensor,
             kv_quant_mode=self._kv_quant_mode,
             k_scale_cache=k_scale_cache,
@@ -670,8 +690,9 @@ class TritonAttentionImpl(AttentionImpl):
             use_td=self.use_td,
         )
 
-        # Apply v_scale post-kernel for FP8 per-tensor path (see comment above).
-        if v_scale_float != 1.0:
+        # Apply v_scale post-kernel when output is bf16 (output_scale=None).
+        # When output is FP8, v_scale was already folded into output_scale.
+        if v_scale_float != 1.0 and output_scale is None:
             output[:num_actual_tokens].mul_(v_scale_float)
 
         return output

--- a/vllm/v1/attention/backends/triton_attn.py
+++ b/vllm/v1/attention/backends/triton_attn.py
@@ -629,10 +629,11 @@ class TritonAttentionImpl(AttentionImpl):
         # softmax_scale and v_scale into output_scale (FlashInfer strategy).
         #
         # NOTE: softmax_scale is a host-side scalar baked into the kernel
-        # launch. With CUDA Graphs + dynamic quantization, the captured
-        # graph will use the scale from capture time.  This matches
-        # FlashInfer's existing approach and is acceptable because scales
-        # stabilize during warmup before graph capture.
+        # launch.  For static quantization (scales loaded from disk), this
+        # is perfectly safe with CUDA Graphs since the value never changes.
+        # For dynamic calibration (calculate_kv_scales=True), scales
+        # stabilize during warmup before graph capture, matching
+        # FlashInfer's existing approach (bmm1_scale/bmm2_scale).
         is_quantized_per_tensor = (
             is_quantized_kv_cache(self.kv_cache_dtype)
             and not self._is_per_token_head_quant

--- a/vllm/v1/attention/backends/triton_attn.py
+++ b/vllm/v1/attention/backends/triton_attn.py
@@ -592,13 +592,10 @@ class TritonAttentionImpl(AttentionImpl):
         # FP8 per-tensor / auto path (original flow).
         else:
             key_cache, value_cache = kv_cache.unbind(1)
-            if is_quantized_kv_cache(self.kv_cache_dtype):
-                if key_cache.dtype != self.fp8_dtype:
-                    key_cache = key_cache.view(self.fp8_dtype)
-                    value_cache = value_cache.view(self.fp8_dtype)
-                assert layer._q_scale_float == 1.0, (
-                    "A non 1.0 q_scale is not currently supported."
-                )
+            is_quantized = is_quantized_kv_cache(self.kv_cache_dtype)
+            if is_quantized and key_cache.dtype != self.fp8_dtype:
+                key_cache = key_cache.view(self.fp8_dtype)
+                value_cache = value_cache.view(self.fp8_dtype)
             descale_shape = (
                 attn_metadata.query_start_loc.shape[0] - 1,
                 key_cache.shape[2],
@@ -622,6 +619,23 @@ class TritonAttentionImpl(AttentionImpl):
 
         mm_prefix_range_tensor = attn_metadata.mm_prefix_range_tensor
 
+        # When Q is FP8 (quantized query) and KV cache is FP8 per-tensor,
+        # the kernel's _cast_kv_tile keeps K/V in FP8 for FP8 MMA and skips
+        # applying k_scale/v_scale.  We fold q_scale * k_scale into
+        # softmax_scale and apply v_scale to the output after the kernel,
+        # matching FlashInfer's strategy.
+        fp8_per_tensor = (
+            not self._is_per_token_head_quant
+            and is_quantized
+            and query.dtype == self.fp8_dtype
+        )
+        if fp8_per_tensor:
+            softmax_scale = self.scale * layer._q_scale_float * layer._k_scale_float
+            v_scale_float = layer._v_scale_float
+        else:
+            softmax_scale = self.scale
+            v_scale_float = 1.0
+
         unified_attention(
             q=query[:num_actual_tokens],
             k=key_cache,
@@ -631,14 +645,14 @@ class TritonAttentionImpl(AttentionImpl):
             max_seqlen_q=max_seqlen_q,
             seqused_k=seqused_k,
             max_seqlen_k=max_seqlen_k,
-            softmax_scale=self.scale,
+            softmax_scale=softmax_scale,
             causal=True,
             alibi_slopes=self.alibi_slopes,
             use_alibi_sqrt=self.use_alibi_sqrt,
             window_size=self.sliding_window,
             block_table=block_table,
             softcap=self.logits_soft_cap,
-            q_descale=None,  # Not supported
+            q_descale=None,
             k_descale=k_descale,
             v_descale=v_descale,
             seq_threshold_3D=seq_threshold_3D,
@@ -655,6 +669,10 @@ class TritonAttentionImpl(AttentionImpl):
             chunk_lookback=self.chunk_lookback,
             use_td=self.use_td,
         )
+
+        # Apply v_scale post-kernel for FP8 per-tensor path (see comment above).
+        if v_scale_float != 1.0:
+            output[:num_actual_tokens].mul_(v_scale_float)
 
         return output
 


### PR DESCRIPTION
Remove the `assert layer._q_scale_float == 1.0` limitation in `TritonAttentionImpl` and properly handle FP8 scales for the per-tensor KV cache path.

When Q is FP8, the kernel's `_cast_kv_tile` keeps K/V in FP8 for tensor-core MMA and skips per-tensor dequantization. We fold the calibrated scales (from checkpoint) into the kernel's scalar arguments following FlashInfer's strategy:

- `q_scale * k_scale` → folded into `softmax_scale`
- `v_scale` → folded into `output_scale` (FP8 output) or applied post-kernel (bf16 output)

Adds a kernel-level test validating correctness with non-trivial scales.

Test:
- Model https://huggingface.co/Yi30/Qwen3-8B-attention-fp8
- Test results:
- BF16 
```bash
local-completions ({'model': '/mnt/disk1/yiliu7/Qwen/Qwen3-8B', 'base_url': 'http://127.0.0.1:8000/v1/completions', 'max_concurrent': 1, 'max_length': 32768, 'max_gen_toks': 128}), gen_kwargs: ({'max_length': 32768, 'max_gen_toks': 128}), limit: None, num_fewshot: None, batch_size: 32
|     Tasks     |Version|Filter|n-shot|Metric|   | Value |   |Stderr|
|---------------|------:|------|-----:|-----:|---|------:|---|------|
|niah_multiquery|      1|none  |     0| 32768|↑  | 0.9965|±  |   N/A|
|               |       |none  |     0|  4096|↑  |-1.0000|±  |   N/A|
```
- Quantized Q/K/V
```
local-completions ({'model': '/mnt/disk1/yiliu7/Yi30/Qwen3-8B-attention-fp8', 'base_url': 'http://127.0.0.1:8000/v1/completions', 'max_concurrent': 1, 'max_length': 32768, 'max_gen_toks': 128}), gen_kwargs: ({'max_length': 32768, 'max_gen_toks': 128}), limit: None, num_fewshot: None, batch_size: 32
|     Tasks     |Version|Filter|n-shot|Metric|   | Value |   |Stderr|
|---------------|------:|------|-----:|-----:|---|------:|---|------|
|niah_multiquery|      1|none  |     0| 32768|↑  | 0.9915|±  |   N/A|
|               |       |none  |     0|  4096|↑  |-1.0000|±  |   N/A|
```