### PR TITLE
[Quantization][INC] Support INT2 XPU Linear

### DIFF
--- a/vllm/model_executor/layers/quantization/inc/schemes/inc_wna16_linear.py
+++ b/vllm/model_executor/layers/quantization/inc/schemes/inc_wna16_linear.py
@@ -277,6 +277,13 @@ class INCXPULinearBase(INCLinearScheme):
 
 
 class INCXPULinearMethod(INCXPULinearBase):
+    def __init__(self, layer_config: "INCLayerConfig") -> None:
+        super().__init__(layer_config)
+        if self.weight_bits != 4 or not self.sym:
+            raise NotImplementedError(
+                "Native XPU INC path only supports 4-bit symmetric weights."
+            )
+
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
         device = layer.qweight.data.device
 

--- a/vllm/model_executor/layers/quantization/inc/schemes/inc_wna16_scheme.py
+++ b/vllm/model_executor/layers/quantization/inc/schemes/inc_wna16_scheme.py
@@ -35,7 +35,7 @@ class INCWna16Scheme(INCScheme):
     ):
         del config, layer
         if current_platform.is_xpu():
-            if layer_config.bits == 4 and layer_config.sym:
+            if layer_config.bits in {2, 4} and layer_config.sym:
                 from .inc_wna16_linear import (
                     INCARKLinearMethod,
                     INCXPULinearMethod,
@@ -45,6 +45,13 @@ class INCWna16Scheme(INCScheme):
                 is_ark_available, ark_error, _, _ = get_ark_state()
                 if is_ark_available:
                     return INCLinearMethod(INCARKLinearMethod(layer_config))
+                if layer_config.bits == 2:
+                    raise NotImplementedError(
+                        "INC int2 on XPU requires the ARK backend. "
+                        f"Layer: {prefix}. "
+                        f"auto_round_kernel unavailable: "
+                        f"{ark_error or 'unknown error'}"
+                    )
 
                 logger.debug(
                     "ARK backend is unavailable for layer %s; "
@@ -56,7 +63,7 @@ class INCWna16Scheme(INCScheme):
             raise NotImplementedError(f"INC on XPU: unsupported config {layer_config}")
 
         if current_platform.is_cpu() and layer_config.is_gptq:
-            if layer_config.bits == 4 and layer_config.sym:
+            if layer_config.bits in {2, 4} and layer_config.sym:
                 from .inc_wna16_linear import (
                     INCARKLinearMethod,
                     INCWNA16LinearScheme,
@@ -66,6 +73,13 @@ class INCWna16Scheme(INCScheme):
                 is_ark_available, ark_error, _, _ = get_ark_state()
                 if is_ark_available:
                     return INCLinearMethod(INCARKLinearMethod(layer_config))
+                if layer_config.bits == 2:
+                    raise NotImplementedError(
+                        "INC int2 GPTQ on CPU requires the ARK backend. "
+                        f"Layer: {prefix}. "
+                        f"auto_round_kernel unavailable: "
+                        f"{ark_error or 'unknown error'}"
+                    )
 
                 logger.debug(
                     "ARK backend is unavailable for layer %s; "


### PR DESCRIPTION
```python
python3 examples/basic/offline_inference/generate.py --model OPEA/Qwen2.5-72B-Instruct-int2-sym-inc --block-size 64 --enforce-eager --max-model-len 512 --tensor-parallel-size 2 --gpu-memory-utilization 0.15
```

<img width="800" height="178" alt="image" src="https://github.com/user-attachments/assets/bbe3cc47-bb0c-4580-9967-6a3374885258" />
